### PR TITLE
allow loopback export authentication

### DIFF
--- a/gsrs-core-entities/src/main/java/gsrs/controller/hateoas/HttpLoopBackConfig.java
+++ b/gsrs-core-entities/src/main/java/gsrs/controller/hateoas/HttpLoopBackConfig.java
@@ -1,0 +1,55 @@
+package gsrs.controller.hateoas;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties("gsrs.loopback")
+public class HttpLoopBackConfig {
+    
+    // TODO: we may be able to simplify this to one
+    // config parameter, much like application.host
+    // it should instead be gsrs.loopback.application.host
+    // as that is the analogous concept.
+    //
+    // It's also probably possible to detect the most
+    // likely loopback based on requests. This is
+    // especially likely when using a microservice
+    // architecture, so some simple "useSelf"
+    // loopback adapter would be useful
+    private String protocol;
+    private String hostname;
+    private int port;
+    
+    
+    private List<Map<String, Object>> requests;
+    public String getProtocol() {
+        return protocol;
+    }
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+    public String getHostname() {
+        return hostname;
+    }
+    public void setHostname(String hostname) {
+        this.hostname = hostname;
+    }
+    public int getPort() {
+        return port;
+    }
+    public void setPort(int port) {
+        this.port = port;
+    }
+    public List<Map<String, Object>> getRequests() {
+        return requests;
+    }
+    public void setRequests(List<Map<String, Object>> requests) {
+        this.requests = requests;
+    }
+    
+    
+}

--- a/gsrs-core-entities/src/main/java/gsrs/controller/hateoas/HttpRequestHolder.java
+++ b/gsrs-core-entities/src/main/java/gsrs/controller/hateoas/HttpRequestHolder.java
@@ -1,0 +1,102 @@
+package gsrs.controller.hateoas;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import gov.nih.ncats.common.Tuple;
+import gsrs.springUtils.GsrsSpringUtils;
+import lombok.Builder;
+
+@Builder
+public class HttpRequestHolder {
+//    @Builder.Default
+//    private HttpEntity<String> entity = new HttpEntity<>("body");
+    
+    @Builder.Default
+    private Map<String,List<String>> headers = new LinkedHashMap<>();
+    
+    @Builder.Default
+    private HttpMethod method = HttpMethod.GET;
+    @Builder.Default
+    private String url;
+    
+    public String getUrl() {
+        return url;
+    }
+    public void setUrl(String url) {
+        this.url = url;
+    }
+    public HttpMethod getMethod() {
+        return method;
+    }
+    public void setMethod(HttpMethod method) {
+        this.method = method;
+    }
+    
+    public void addHeader(String key, String v) {
+        if(headers==null) {
+            headers= new LinkedHashMap<>();
+        }
+       headers.computeIfAbsent(key, kk-> new ArrayList<>())
+              .add(v);
+       
+    }
+    
+    public ResponseEntity<String> execute(RestTemplate restTemplate) {
+        String curl=url;
+        // Tyler Peryea: This section is unfortunately necessary as
+        // the restTemplate itself considers all URLs provided to be not-yet percent encoded
+        // so, in a rather silly turn of events we need to UNencode the URL before sending it
+        // to restTemplate to be re-encoded.
+        try {
+            curl = URLDecoder.decode(url, "UTF-8");
+        } catch (UnsupportedEncodingException e1) {
+            e1.printStackTrace();
+        } // java.net class
+        HttpHeaders httpheaders = new HttpHeaders();
+        headers.forEach((k,v)->{
+            httpheaders.addAll(k, v);
+        });
+        HttpEntity<String> entity = new HttpEntity<>("body",httpheaders);
+        
+        return restTemplate.exchange(curl, method, entity, String.class);
+    }
+    
+    public static HttpRequestHolder fromRequest(HttpServletRequest req) {
+        HttpRequestHolder holder=HttpRequestHolder.builder()
+        .url(req.getRequestURL() + Optional.ofNullable(req.getQueryString()).map(qq->"?"+qq).orElse(""))
+        .method(HttpMethod.resolve(req.getMethod()))
+        .build();
+        GsrsSpringUtils.toHeadersMap(req).forEach((k,v)->{
+            for(String v2:v) {
+                holder.addHeader(k, v2);
+            }
+        });
+        
+        return holder;
+    }
+    public Map<String, List<String>> getHeaders() {
+        return headers;
+    }
+    public void setHeaders(Map<String, List<String>> headers) {
+        this.headers = headers;
+    }
+    
+    
+    
+    
+}

--- a/gsrs-core-entities/src/main/java/gsrs/controller/hateoas/LoopbackWebRequestHelper.java
+++ b/gsrs-core-entities/src/main/java/gsrs/controller/hateoas/LoopbackWebRequestHelper.java
@@ -1,0 +1,227 @@
+package gsrs.controller.hateoas;
+
+import java.net.URI;
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import gov.nih.ncats.common.Tuple;
+import gov.nih.ncats.common.util.Holder;
+
+
+
+@Component
+public class LoopbackWebRequestHelper implements ApplicationListener<ContextRefreshedEvent>{
+
+    @Autowired
+    private HttpLoopBackConfig httpLoopBackConfig;
+    
+
+    private Map<String, RequestAdapter> adapterMapByContext;
+    private RequestAdapter defaultAdapter;
+
+    @Override
+    public void onApplicationEvent(ContextRefreshedEvent event) {
+        if(httpLoopBackConfig!=null) {
+            Holder<RequestAdapter> defaultHolder = Holder.hold(null);
+            ObjectMapper mapper = new ObjectMapper();
+            adapterMapByContext = httpLoopBackConfig.getRequests().stream()
+                    .map(m-> mapper.convertValue(m, WebRequestConfig.class))
+                    .filter(m->{
+                        if(m.isDefault()){
+                            defaultHolder.set( getRequestAdapter(mapper, m));
+                            return false;
+                        }else{
+                            return true;
+                        }
+                    })
+                    .collect(Collectors.toMap(WebRequestConfig::getContext, c-> getRequestAdapter(mapper, c)));
+            defaultAdapter = defaultHolder.get();
+        }
+    }
+
+    public HttpRequestHolder createNewLoopbackRequestFromCurrentRequest(HttpRequestHolder holder){
+        return createNewLoopbackRequestFromCurrentRequest(holder, null);
+    }
+    
+    public HttpRequestHolder createNewLoopbackRequestFromCurrentRequest(HttpRequestHolder holder, String context){
+        HttpServletRequest request = 
+                ((ServletRequestAttributes)RequestContextHolder.getRequestAttributes())
+                        .getRequest();
+        HttpRequestHolder sourceHold = HttpRequestHolder.fromRequest(request);
+        return adapt(holder, sourceHold, adapterMapByContext.get(context));
+    }
+    
+    
+    public HttpRequestHolder createNewLoopbackRequestFrom(HttpRequestHolder holder, HttpRequestHolder currentRequest) {
+        return adapt(holder,currentRequest, null);
+    }
+    
+    public HttpRequestHolder createNewLoopbackRequestFrom(HttpRequestHolder holder, HttpRequestHolder currentRequest, String context){
+        RequestAdapter adapter = adapterMapByContext.get(context);
+        return adapt(holder, currentRequest, adapter);
+    }
+  
+
+    private HttpRequestHolder adapt(HttpRequestHolder holdersrc, HttpRequestHolder currentRequest, RequestAdapter adapter) {
+        String transformedURL;
+        try {
+            URI urlObj = new URL(holdersrc.getUrl()).toURI();
+
+
+            transformedURL = new URI(httpLoopBackConfig.getProtocol(), 
+                                     httpLoopBackConfig.getHostname() +":"+ 
+                                     httpLoopBackConfig.getPort(),
+                                                urlObj.getPath(),     //TODO: TP 08-15-2021 I'm not so sure about this ... the local loopback could
+                                                                      //be different than the path of the built query. Care needs
+                                                                      //to be taken here
+                                                urlObj.getQuery(), 
+                                                urlObj.getFragment())
+                    .toString();
+        } catch (Exception e) {
+            throw new IllegalArgumentException(e);
+        }
+        HttpRequestHolder requestHolder = HttpRequestHolder.builder()
+                .url(transformedURL)
+                .headers(holdersrc.getHeaders())
+                .method(holdersrc.getMethod())
+                .build();
+        if(adapter !=null) {
+            return adapter.adaptHolder(requestHolder, currentRequest);
+        }
+        return defaultAdapter.adaptHolder(requestHolder, currentRequest);
+    }
+
+
+    private RequestAdapter getRequestAdapter(ObjectMapper mapper, WebRequestConfig c) {
+        Map<String, Object> map;
+        if(c.getParameters() ==null){
+           map = Collections.emptyMap();
+        }else{
+            map = c.getParameters();
+        }
+        try {
+            
+            //This deals with the unfortunate tendency of the HOCON parser
+            //for spring boot to deserialize JSON arrays into Map<Integer,Object>
+            //instead of List<Object> or equivalent. This needs a deeper solution
+            //perhaps involving jackson or the HOCON property parser itself
+            map = map.entrySet().stream()
+            .map(Tuple::of)
+            .map(Tuple.vmap(v->{
+                if(v instanceof LinkedHashMap) {
+                    LinkedHashMap lhm = (LinkedHashMap)v;
+                    if(lhm.keySet().stream()
+                    .allMatch(kk->{
+                        try {
+                            Integer ind = Integer.parseInt(kk+"");
+                            if(ind!=null)return true;
+                        }catch(Exception e) {
+                        }
+                        return false;
+                    })) {
+                        return lhm.values();
+                    }
+                }
+                return v;
+                                
+            }))
+            .collect(Tuple.toMap());
+            
+            
+            return (RequestAdapter) mapper.convertValue(map, LoopbackWebRequestHelper.class.getClassLoader().loadClass(c.getClassname()));
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+
+    public interface RequestAdapter{
+        HttpRequestHolder adaptHolder(HttpRequestHolder holder, HttpRequestHolder sourceRequest);
+    }
+    public static class WebRequestConfig{
+        public String context;
+        public String classname;
+        public boolean isDefault;
+        public Map<String, Object> parameters;
+
+        public boolean isDefault() {
+            return isDefault;
+        }
+
+        public void setDefault(boolean aDefault) {
+            isDefault = aDefault;
+        }
+
+        public String getContext() {
+            return context;
+        }
+
+        public void setContext(String context) {
+            this.context = context;
+        }
+
+        public String getClassname() {
+            return classname;
+        }
+
+        public void setClassname(String classname) {
+            this.classname = classname;
+        }
+
+        public Map<String, Object> getParameters() {
+            return parameters;
+        }
+
+        public void setParameters(Map<String, Object> parameters) {
+            this.parameters = parameters;
+        }
+    }
+
+    public static class AuthHeaderRequestAdapter implements RequestAdapter{
+
+        private Set<String> authHeaders = new HashSet<>();
+
+        public Set<String> getAuthHeaders() {
+            return authHeaders;
+        }
+
+        public void setAuthHeaders(Set<String> authHeaders) {
+            this.authHeaders = authHeaders;
+        }
+        
+        @Override
+        public HttpRequestHolder adaptHolder(HttpRequestHolder holder, HttpRequestHolder sourceRequest) {
+            if(authHeaders.isEmpty()){
+                return holder;
+            }
+            Map<String, List<String>> headers = sourceRequest.getHeaders();
+            for(String key : authHeaders){
+                List<String> value = headers.get(key);
+                if(value !=null && value.size() > 0){
+                    for(String v : value) {
+                        holder.addHeader(key, v);
+                    }
+                }
+            }
+            return holder;
+        }
+    }
+   
+}

--- a/gsrs-core/src/main/java/gsrs/SpecialFieldsProperties.java
+++ b/gsrs-core/src/main/java/gsrs/SpecialFieldsProperties.java
@@ -11,14 +11,13 @@ import java.util.Map;
 public class SpecialFieldsProperties {
 
     private List<Map<String, Object>> exactsearchfields;
-//.exactsearchfields
 
     public List<Map<String, Object>> getExactsearchfields() {
         return exactsearchfields;
     }
 
-    public void setExactsearchfields(List<Map<String, Object>> registeredfunctions) {
-        this.exactsearchfields = registeredfunctions;
+    public void setExactsearchfields(List<Map<String, Object>> exactsearchfields) {
+        this.exactsearchfields = exactsearchfields;
     }
 
 

--- a/gsrs-core/src/main/java/gsrs/springUtils/GsrsSpringUtils.java
+++ b/gsrs-core/src/main/java/gsrs/springUtils/GsrsSpringUtils.java
@@ -1,11 +1,15 @@
 package gsrs.springUtils;
 
-import gov.nih.ncats.common.util.Unchecked;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
 
-import java.net.URI;
-import java.util.function.Consumer;
+import gov.nih.ncats.common.Tuple;
+import gov.nih.ncats.common.stream.StreamUtil;
+import gov.nih.ncats.common.util.Unchecked;
 
 public class GsrsSpringUtils {
 
@@ -22,6 +26,14 @@ public class GsrsSpringUtils {
         }else {
             return req.getRequestURL().toString() + "?" + req.getQueryString();
         }
+    }
+    
+    public static Map<String,List<String>> toHeadersMap(HttpServletRequest parentRequest){
+        Map<String, List<String>> headers = StreamUtil.forEnumeration(parentRequest.getHeaderNames())
+                .map(n->Tuple.of(n,n))
+                .map(Tuple.vmap(n->StreamUtil.forEnumeration(parentRequest.getHeaders(n)).collect(Collectors.toList())))
+                .collect(Tuple.toMap());
+        return headers;
     }
 
     public static void tryTaskAtMost(Unchecked.ThrowingRunnable t, Consumer<Throwable> cons, int n) {

--- a/gsrs-core/src/main/java/ix/core/util/EntityUtils.java
+++ b/gsrs-core/src/main/java/ix/core/util/EntityUtils.java
@@ -1138,22 +1138,35 @@ public class EntityUtils {
 
 		Map<String, MethodOrFieldMeta> apiFields;
 
+		private Set<String> specialFields=null;
+		
 		//Some simple factory helper methods
 
 		//TODO katzelda October 2020 : for now remove exact fields list we can implement this support later
 		//TODO tylerperyea July 2021 : It's later, we need to support this.
 		public Set<String> getSpecialFields() {
-		    return StaticContextAccessor.getOptionalBean(SpecialFieldsProperties.class)
+		    if(specialFields!=null)return specialFields;
+		    
+		    specialFields= StaticContextAccessor.getOptionalBean(SpecialFieldsProperties.class)
 		    .map(sfp->sfp.getExactsearchfields().stream()
 		            
 		            .filter(m->this.getName().equals(m.get("class")))
 		            // Spring / HOCON parser parses JSON array as LinkedHashMap
 		            // with integer keys. Must transform to a list
-		            .flatMap(m->((Map<?,String>) m.get("fields")).values().stream())
 
+                    .map(m->{
+                        if(m instanceof Map) {
+                            return (Collection<String>)(((Map<?,String>) m.get("fields")).values());
+                        }else {
+                            return (Collection<String>)m;
+                        }
+                    })
+                    
+		            .flatMap(m->m.stream())
 		            .collect(Collectors.toSet())
 		            )
 		    .orElse(new HashSet<>());
+		    return specialFields;
 		    
 		}
 

--- a/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/GsrsApiSelector.java
+++ b/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/GsrsApiSelector.java
@@ -1,6 +1,8 @@
 package gsrs;
 
 import gsrs.controller.*;
+import gsrs.controller.hateoas.HttpLoopBackConfig;
+import gsrs.controller.hateoas.LoopbackWebRequestHelper;
 import gsrs.entityProcessor.BasicEntityProcessorConfiguration;
 import gsrs.entityProcessor.ConfigBasedEntityProcessorConfiguration;
 import gsrs.events.listeners.ReindexEventListener;
@@ -79,6 +81,11 @@ public class GsrsApiSelector implements ImportSelector {
         componentsToInclude.add(RegisteredFunctionProperties.class);
         componentsToInclude.add(ExportController.class);
         componentsToInclude.add(SearchResultController.class);
+        
+        
+        componentsToInclude.add(LoopbackWebRequestHelper.class);
+        componentsToInclude.add(HttpLoopBackConfig.class);
+
         return componentsToInclude.stream().map(Class::getName)
                 .peek(c-> System.out.println(c)).toArray(i-> new String[i]);
     }

--- a/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/autoconfigure/GsrsApiAutoConfiguration.java
+++ b/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/autoconfigure/GsrsApiAutoConfiguration.java
@@ -10,22 +10,31 @@ import gsrs.buildInfo.BuildInfoConfiguration;
 import gsrs.buildInfo.VersionFileBuildInfoFetcherConfiguation;
 import gsrs.controller.GsrsApiControllerAdvice;
 import gsrs.controller.GsrsControllerConfiguration;
+import gsrs.controller.hateoas.HttpLoopBackConfig;
 import gsrs.controller.hateoas.IxContext;
+import gsrs.controller.hateoas.LoopbackWebRequestHelper;
 import gsrs.service.DefaultExportService;
 import gsrs.springUtils.AutowireHelper;
 import gsrs.validator.ConfigBasedGsrsValidatorFactory;
 
 @Configuration
 //can't do component scan in autoconfiguration so manually import our components
-@Import(value = {AutowireHelper.class, GsrsControllerConfiguration.class,
+@Import(value = {AutowireHelper.class, 
+        GsrsControllerConfiguration.class,
         GsrsApiControllerAdvice.class,
-         GsrsFactoryConfiguration.class, ConfigBasedGsrsValidatorFactory.class,
-        JsonTypeIdResolverConfiguration.class, RegisteredFunctionProperties.class,
-        GsrsExportConfiguration.class, DefaultExportService.class,
-        BuildInfoConfiguration.class, VersionFileBuildInfoFetcherConfiguation.class,
+        GsrsFactoryConfiguration.class, 
+        ConfigBasedGsrsValidatorFactory.class,
+        JsonTypeIdResolverConfiguration.class, 
+        RegisteredFunctionProperties.class,
+        GsrsExportConfiguration.class, 
+        DefaultExportService.class,
+        BuildInfoConfiguration.class, 
+        VersionFileBuildInfoFetcherConfiguation.class,
         GsrsApiWebConfiguration.class,
-        IxContext.class
-        })
+        IxContext.class,
+        LoopbackWebRequestHelper.class,
+        HttpLoopBackConfig.class
+})
 public class GsrsApiAutoConfiguration {
 
 

--- a/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/controller/EtagLegacySearchEntityController.java
+++ b/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/controller/EtagLegacySearchEntityController.java
@@ -1,15 +1,19 @@
 package gsrs.controller;
 
 
+import gov.nih.ncats.common.Tuple;
+import gov.nih.ncats.common.stream.StreamUtil;
 import gov.nih.ncats.common.util.Unchecked;
 import gsrs.autoconfigure.GsrsExportConfiguration;
 import gsrs.controller.hateoas.GsrsLinkUtil;
 import gsrs.controller.hateoas.GsrsUnwrappedEntityModel;
+import gsrs.controller.hateoas.HttpRequestHolder;
 import gsrs.model.GsrsUrlLink;
 import gsrs.repository.ETagRepository;
 import gsrs.service.EtagExportGenerator;
 import gsrs.service.ExportGenerator;
 import gsrs.service.ExportService;
+import gsrs.springUtils.GsrsSpringUtils;
 import ix.core.controllers.EntityFactory;
 import ix.core.models.ETag;
 import ix.core.search.SearchResult;
@@ -120,12 +124,20 @@ GET     /$context<[a-z0-9_]+>/export/:etagId/:format               ix.core.contr
         private String extension;
         private GsrsUnwrappedEntityModel.RestUrlLink link;
     }
+    
+
+    
     @PreAuthorize("isAuthenticated()")
     @GetGsrsRestApiMapping("/export/{etagId}/{format}")
-    public ResponseEntity<Object> createExport(@PathVariable("etagId") String etagId, @PathVariable("format") String format,
-                                               @RequestParam(value = "publicOnly", required = false) Boolean publicOnlyObj, @RequestParam(value ="filename", required= false) String fileName,
+    public ResponseEntity<Object> createExport(@PathVariable("etagId") String etagId, 
+                                               @PathVariable("format") String format,
+                                               @RequestParam(value = "publicOnly", required = false) Boolean publicOnlyObj, 
+                                               @RequestParam(value ="filename", required= false) String fileName,
                                                Principal prof,
-                                               @RequestParam Map<String, String> parameters) throws Exception {
+                                               @RequestParam Map<String, String> parameters,
+                                               HttpServletRequest request
+                                               
+            ) throws Exception {
         Optional<ETag> etagObj = eTagRepository.findByEtag(etagId);
 
         boolean publicOnly = publicOnlyObj==null? true: publicOnlyObj;
@@ -138,8 +150,11 @@ GET     /$context<[a-z0-9_]+>/export/:etagId/:format               ix.core.contr
         ExportMetaData emd=new ExportMetaData(etagId, etagObj.get().uri, prof.getName(), publicOnly, format);
 
 
+        
         //Not ideal, but gets around user problem
-        Stream<T> mstream = new EtagExportGenerator<T>(entityManager, transactionManager).generateExportFrom(getEntityService().getContext(), etagObj.get()).get();
+        Stream<T> mstream = new EtagExportGenerator<T>(entityManager, transactionManager, HttpRequestHolder.fromRequest(request))
+                .generateExportFrom(getEntityService().getContext(), etagObj.get())
+                .get();
 
         //GSRS-699 REALLY filter out anything that isn't public unless we are looking at private data
 //        if(publicOnly){

--- a/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/search/SearchResultController.java
+++ b/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/search/SearchResultController.java
@@ -90,8 +90,6 @@ public class SearchResultController {
         }
         SearchResultContext ctx=possibleContext.getContext();
 
-
-        URI originalURI = new URI(ctx.getGeneratingUrl());
         
         //Play used a Map<String,String[]> while Spring uses a MultiMap<String,String>
         Map<String, String[]> paramMap =queryParameters.entrySet().stream()

--- a/gsrs-spring-boot-autoconfigure/src/main/resources/gsrs-core.conf
+++ b/gsrs-spring-boot-autoconfigure/src/main/resources/gsrs-core.conf
@@ -86,3 +86,26 @@ gsrs.validators = {}
 ix.index.rootIndexOnly = true
 
 
+
+#################
+#  LOOPBACK WEB REQUESTS START
+#################
+gsrs.loopback.hostname="localhost"
+gsrs.loopback.protocol="http"
+#default port
+gsrs.loopback.port=8080
+#this is an optional override if user sets -Dhttp.port this set the gsrs.loopback.port to that value
+gsrs.loopback.port=${?http.port}
+gsrs.loopback.requests=[
+	{
+	"isDefault" : true,
+	"classname" : "gsrs.controller.hateoas.LoopbackWebRequestHelper$AuthHeaderRequestAdapter",
+	"parameters" : {
+                "authHeaders":["auth-token", "auth-username", "auth-password", "Cookie", "cookie"]
+               		}
+	}
+]
+
+#################
+#  LOOPBACK WEB REQUESTS END
+#################


### PR DESCRIPTION
This allows export requests that use the REST API to have a configurable loopback address and preserve the session/etc information. This can likely be simplified as it would currently require all microservices to have their own loopback specification depending on configuration. However, this is a fairly faithful port of the procedures used in 2.X