### PR TITLE
Allow custom SearchOptions changes for entities, like date ranges

### DIFF
--- a/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/controller/AbstractLegacyTextSearchGsrsEntityController.java
+++ b/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/controller/AbstractLegacyTextSearchGsrsEntityController.java
@@ -71,6 +71,7 @@ public abstract class AbstractLegacyTextSearchGsrsEntityController<C extends Abs
                 .ffilter("")
                 .withParameters(request.getParameterMap())
                 .build();
+        so = this.instrumentSearchOptions(so);
 
         TextIndexer.TermVectors tv= getlegacyGsrsSearchService().getTermVectorsFromQuery(query.orElse(null), so, field.orElse(null));
         return tv.getFacet(so.getFdim(), so.getFskip(), so.getFfilter(), StaticContextAccessor.getBean(IxContext.class).getEffectiveAdaptedURI(request).toString());
@@ -91,6 +92,8 @@ public abstract class AbstractLegacyTextSearchGsrsEntityController<C extends Abs
                 .withParameters(Util.reduceParams(request.getParameterMap(),
                         "fdim", "fskip", "ffilter"))
                 .build();
+        
+        so = this.instrumentSearchOptions(so);
 
         TextIndexer.TermVectors tv = getlegacyGsrsSearchService().getTermVectors(field);
         return tv.getFacet(so.getFdim(), so.getFskip(), so.getFfilter(), StaticContextAccessor.getBean(IxContext.class).getEffectiveAdaptedURI(request).toString());
@@ -141,18 +144,8 @@ GET     /suggest       ix.core.controllers.search.SearchFactory.suggest(q: Strin
         SearchRequest searchRequest = builder.withParameters(request.getParameterMap())
                 .build();
 
-/*
-SearchRequest req = builder
-                .top(top)
-                .skip(skip)
-                .fdim(fdim)
-                .kind(kind)
-                .withRequest(request()) // I don't like this,
-                                        // I like being explicit,
-                                        // but it's ok for now
-                .query(q)
-                .build();
- */
+        this.instrumentSearchRequest(searchRequest);
+        
         SearchResult result = null;
         try {
             result = getlegacyGsrsSearchService().search(searchRequest.getQuery(), searchRequest.getOptions() );

--- a/gsrs-spring-legacy-indexer/src/main/java/ix/core/search/GsrsLegacySearchController.java
+++ b/gsrs-spring-legacy-indexer/src/main/java/ix/core/search/GsrsLegacySearchController.java
@@ -30,5 +30,15 @@ public interface GsrsLegacySearchController {
                                            @RequestParam("fdim") Optional<Integer> fdim,
                                            HttpServletRequest request,
                                            @RequestParam Map<String, String> queryParameters);
+    
+    default SearchOptions instrumentSearchOptions(SearchOptions so) {
+        return so;
+    }
+    
+    default SearchRequest instrumentSearchRequest(SearchRequest sr) {
+        SearchOptions so =instrumentSearchOptions(sr.getOptions());
+        sr.setOptions(so);
+        return sr;
+    }
 
 }

--- a/gsrs-spring-legacy-indexer/src/main/java/ix/core/search/SearchRequest.java
+++ b/gsrs-spring-legacy-indexer/src/main/java/ix/core/search/SearchRequest.java
@@ -94,6 +94,11 @@ public class SearchRequest {
 			return this;
 		}
 
+		public Builder addDateRangeFacet(String facetName) {
+		    opBuilder.addDateRangeFacet(facetName);
+		    return this;
+		}
+
 		public Builder order(List<String> order) {
 			opBuilder.order(order);
 			return this;


### PR DESCRIPTION
This an implementation to allow Controllers to override the way SearchOptions get built (add new default facets/filters/date range facet filters, etc). There are also some convenience methods to add named date range fields as facets, which is the main reason we need this.

There is a corresponding PR for substances to add specific anticipated date fields.