### PR TITLE
Fix quotes removal issue on searches

### DIFF
--- a/gsrs-spring-legacy-indexer/src/main/java/ix/core/search/text/TextIndexer.java
+++ b/gsrs-spring-legacy-indexer/src/main/java/ix/core/search/text/TextIndexer.java
@@ -1337,7 +1337,7 @@ public class TextIndexer implements Closeable, ProcessListener {
         
       
         private static final Pattern QUOTES_AROUND_WORD_REMOVER = Pattern
-                .compile("\"([^\" :.-]*)\"");
+                .compile("\"([^\" .-]*)\"");
 
         public IxQueryParser(String def) {
             super(def, createIndexAnalyzer());

--- a/gsrs-spring-legacy-indexer/src/test/java/ix/core/search/QueryParseTest.java
+++ b/gsrs-spring-legacy-indexer/src/test/java/ix/core/search/QueryParseTest.java
@@ -18,9 +18,9 @@ import ix.core.search.text.TextIndexer.IxQueryParser;
 public class QueryParseTest {
 
     private static final Pattern QUOTES_AROUND_WORD_REMOVER = Pattern
-            .compile("\"([^\" :.-]*)\"");
+            .compile("\"([^\" .-]*)\"");
     final static String[] BREAK_TOKENS = new String[] {
-            " ", ".", "-", ":"      
+            " ", ".", "-"      
           };
 
     @Test


### PR DESCRIPTION
I jumped the gun on this fix last time. The original intent was to make sure that contains searches with quotes ("*spiri*") properly get executed in the backend. For some reason the default lucene text search parts (not the query parse parts), really don't like it if you give what it considers a "ComplexPhraseQuery" that contains a WildcardQuery. In practice this means that you can specify a multi-word wildcard query with quotes UNLESS that query is also a single word. This is quite strange and deserves investigation.

However, in the short term, we noticed the difference between having and discarding quotes on a single word is meaningless, so we could just remove the quotes on single word queries without issue.

The problem is that the meaning of "single word" isn't actually as clear as we may like. I had implemented a rule that just used spaces to detect words. But the default Lucene tokenizer is `StandardTokenizer` and does this:

> As of Lucene version 3.1, this class implements the Word Break rules from the Unicode Text Segmentation algorithm, as specified in Unicode Standard Annex #29.

http://unicode.org/reports/tr29/

The procedures behind these word boundary rules are not at all straight-forward to detect. However, for our purposes, ".",":","-" and space should deal with most of the cases we care about. A more thorough treatment of this could be achieved at a later time. For now it should be sufficient to ensure that common character which are typically treated as split characters are considered split characters here.