### PR TITLE
WIP: Don't merge cached deserialized prinicipal unless necessary

### DIFF
--- a/gsrs-spring-legacy-indexer/src/main/java/ix/core/search/LazyList.java
+++ b/gsrs-spring-legacy-indexer/src/main/java/ix/core/search/LazyList.java
@@ -155,7 +155,9 @@ public class LazyList<N,T> implements List<T>{
 		try{
 			NamedCallable<N,T> nc=_internalList.get(index);
 			try {
-				return nc.call();
+				T tt= nc.call();
+				
+				return tt;
 			} catch (Exception e) {
 				log.error("Named callable with name:" + nc.getName().toString() + " could not be fetched", e);
 


### PR DESCRIPTION
If the principal cache is stale for some reason, like an email address change or change in capitalization on a username, it will have trouble when trying to merge the principal with the entityManager. Essentially it will be trying to put a stale version of the principal into a transaction and there are several safe guards against that which throw exceptions.

In actual practice, it's usually okay to have a stale principal in the deserialization steps. That's because when we deserialize a JSON for a substance, say, and we're deserializing a principal, it's almost always to:

1. Update a substance (which will use PojoPatch to mutate another object, and doesn't need to be tracked by an entityManager)
2. Fetch from the backup tables JSON, which is exclusively used in read-only mode to speed up requests.

In both of the scenarios above, there is no need to merge the principal to an entity manager. This change will stop read-only transactions from bothering to merge with the EM, taking care of the 2 cases above.