### PR TITLE
WIP: Search indexing of NA and proteins at update/create time.

### DIFF
--- a/gsrs-spring-legacy-sequence-indexer/src/main/java/ix/seqaln/SequenceIndexerEventListener.java
+++ b/gsrs-spring-legacy-sequence-indexer/src/main/java/ix/seqaln/SequenceIndexerEventListener.java
@@ -136,7 +136,7 @@ public class SequenceIndexerEventListener {
                     //time. This leads to some strange situations.
                     
                     //The indexer is designed to know whether the indexed sequence is an NA or
-                    //protein, and if it's not known at index time it won't actualy be returned in
+                    //protein, and if it's not known at index time it won't actually be returned in
                     //later searches. 
                     
                     //While it's possible to know, for sure, that the sequence is a protein. It's 
@@ -159,7 +159,7 @@ public class SequenceIndexerEventListener {
                         long ncount = fcount-missingNs.length();
                         //if more than half of the residues are unknown, it's probably not actually
                         //an NA. Otherwise, just assume it is an NA.
-                        if(ncount>fcount*0.5) {                          
+                        if(ncount<fcount*0.5) {                          
                             indexer.add(k.getIdString(), nts);
                         }
                         


### PR DESCRIPTION
When subunits in substances are indexed they are fetched directly from the database based on a key, rather than the POJO being passed from the actual save/update event. At that point they don't retain their parent relationship back to the protein or nucleic acid, which is set on `@PreUpdate` and `@PrePersist` events on the parent `Protein` and `NucleicAcid` records (the `adoptChildSubunits` method). So a given `Subunit` will be "parentless" when fetched this way.

The sequence indexer requires sequences to indexed as either proteins or nucleic acids, and it uses the parent link to determine which kind of subunit is present. If the parent is null, the type is returned as "unknown". In such a case it indexes sequences in a different way that is no longer recoverable from API calls.

The reason it sometimes has worked in the past is because if you re-index everything it actually uses a different fully qualified and parent linked version of the subunits which is created and stored with a ReindexingEvent. There is no such mechanism with creation and update reindexing events. It's also possible that sometimes the EntityManager would cache/attach a version just saved and the fetch from a key _could_ sometimes still have parents present.

This fix is a band-aid fix which just decides to index an unknown sequence twice (once as a protein and once as an NA) rather than trying to rework the event pipeline, subunit model, or subunit type logic. All of those changes should also be done eventually.

This is a WIP and at least needs some unit tests first.