### PR TITLE
WIP attempt to fix indexing of sequencing type 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: java
-
+#this will run this on open jdks for both java 8 and java 11
+jdk:
+  - openjdk8
+  - openjdk11
 #this will reuse maven dependencies so it doesn't redownload everytime
 cache:
   directories:

--- a/gsrs-core-entities/src/main/java/gsrs/indexer/DefaultIndexerEventFactory.java
+++ b/gsrs-core-entities/src/main/java/gsrs/indexer/DefaultIndexerEventFactory.java
@@ -1,0 +1,22 @@
+package gsrs.indexer;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+
+/**
+ * Default implementation of {@link IndexerEventFactory}
+ * that creates IndexEvents for any Object.  It has an `{@link #getOrder()}
+ * that returns {@link Ordered#LOWEST_PRECEDENCE} so that
+ * it will always be last in the list of factories.
+ */
+public class DefaultIndexerEventFactory implements IndexerEventFactory{
+    @Override
+    public boolean supports(Object object) {
+        return true;
+    }
+    // last order to be last in a sorted list
+    @Override
+    public int getOrder() {
+        return Ordered.LOWEST_PRECEDENCE;
+    }
+}

--- a/gsrs-core-entities/src/main/java/gsrs/indexer/DefaultIndexerEventFactoryFactory.java
+++ b/gsrs-core-entities/src/main/java/gsrs/indexer/DefaultIndexerEventFactoryFactory.java
@@ -1,0 +1,27 @@
+package gsrs.indexer;
+
+import lombok.Data;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Data
+public class DefaultIndexerEventFactoryFactory implements IndexerEventFactoryFactory{
+    @Autowired(required = false)
+    private List<IndexerEventFactory> factories = Arrays.asList(new DefaultIndexerEventFactory());
+    @Override
+    public IndexerEventFactory getIndexerFactoryFor(Object o) {
+        if(factories !=null){
+            for(IndexerEventFactory f : factories){
+                if(f.supports(o)){
+                    return f;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/gsrs-core-entities/src/main/java/gsrs/indexer/IndexerEntityListener.java
+++ b/gsrs-core-entities/src/main/java/gsrs/indexer/IndexerEntityListener.java
@@ -21,6 +21,9 @@ public class IndexerEntityListener {
     @Autowired
     private ApplicationEventPublisher applicationEventPublisher;
 
+    @Autowired
+    private IndexerEventFactoryFactory indexerEventFactoryFactory;
+
     private void autowireIfNeeded(){
         if(applicationEventPublisher ==null) {
             AutowireHelper.getInstance().autowire(this);
@@ -31,7 +34,10 @@ public class IndexerEntityListener {
         autowireIfNeeded();
         EntityUtils.EntityWrapper<Object> ew = EntityUtils.EntityWrapper.of(obj);
         if(ew.shouldIndex()) {
-            applicationEventPublisher.publishEvent(new IndexCreateEntityEvent(ew.getKey()));
+            IndexerEventFactory indexerFactoryFor = indexerEventFactoryFactory.getIndexerFactoryFor(obj);
+            if(indexerFactoryFor !=null) {
+                applicationEventPublisher.publishEvent(indexerFactoryFor.newCreateEventFor(ew));
+            }
         }
     }
 
@@ -40,7 +46,10 @@ public class IndexerEntityListener {
         autowireIfNeeded();
         EntityUtils.EntityWrapper ew = EntityUtils.EntityWrapper.of(obj);
         if(ew.shouldIndex()) {
-            applicationEventPublisher.publishEvent(new IndexUpdateEntityEvent(ew.getKey()));
+            IndexerEventFactory indexerFactoryFor = indexerEventFactoryFactory.getIndexerFactoryFor(obj);
+            if(indexerFactoryFor !=null) {
+                applicationEventPublisher.publishEvent(indexerFactoryFor.newUpdateEventFor(ew));
+            }
         }
     }
     @PostRemove
@@ -48,7 +57,10 @@ public class IndexerEntityListener {
         autowireIfNeeded();
         EntityUtils.EntityWrapper ew = EntityUtils.EntityWrapper.of(obj);
         if(ew.shouldIndex()) {
-            applicationEventPublisher.publishEvent(new IndexRemoveEntityEvent(ew));
+            IndexerEventFactory indexerFactoryFor = indexerEventFactoryFactory.getIndexerFactoryFor(obj);
+            if(indexerFactoryFor !=null) {
+                applicationEventPublisher.publishEvent(indexerFactoryFor.newRemoveEventFor(ew));
+            }
         }
     }
 }

--- a/gsrs-core-entities/src/main/java/gsrs/indexer/IndexerEventFactory.java
+++ b/gsrs-core-entities/src/main/java/gsrs/indexer/IndexerEventFactory.java
@@ -1,0 +1,69 @@
+package gsrs.indexer;
+
+import ix.core.util.EntityUtils;
+import org.springframework.core.Ordered;
+
+/**
+ * Factory to create Indexing events for a given Object.
+ * GSRS will have several IndexerEventFactories loaded
+ * and when an Object is to be indexed, it will iterate through each one
+ * of these Factories to see which one to use.
+ * The first supported Factory that is found will have its corresponding
+ * {@link #newCreateEventFor(EntityUtils.EntityWrapper)},
+ * {@link #newUpdateEventFor(EntityUtils.EntityWrapper)}
+ * or {@link #newRemoveEventFor(EntityUtils.EntityWrapper)} method
+ * with the Object passed in to {@link #supports(Object)} wrapped in an {@link ix.core.util.EntityUtils.EntityWrapper}.
+ *
+ * By default, the default implementations will make the base {@link IndexCreateEntityEvent}, {@link IndexUpdateEntityEvent}
+ * and {@link IndexRemoveEntityEvent} respectively.
+ */
+public interface IndexerEventFactory extends Ordered {
+    /**
+     * Create a new CreateIndexEvent object for the given wrapped Entity.
+     * The returned Object will be published to the {@link org.springframework.context.ApplicationEventPublisher}.
+     * @param ew the {@link ix.core.util.EntityUtils.EntityWrapper} wrapping the Object that returned {@code true}
+     *           if it was supported by this indexerFactory.
+     * @return the event object to publish; or {@code null} if nothing should be published.
+     *
+     */
+    default Object newCreateEventFor(EntityUtils.EntityWrapper ew){
+        return new IndexCreateEntityEvent(ew.getKey());
+    }
+    /**
+     * Create a new UpdateIndexEvent object for the given wrapped Entity.
+     * The returned Object will be published to the {@link org.springframework.context.ApplicationEventPublisher}.
+     * @param ew the {@link ix.core.util.EntityUtils.EntityWrapper} wrapping the Object that returned {@code true}
+     *           if it was supported by this indexerFactory.
+     * @return the event object to publish; or {@code null} if nothing should be published.
+     */
+    default Object newUpdateEventFor(EntityUtils.EntityWrapper ew){
+        return new IndexUpdateEntityEvent(ew.getKey());
+    }
+    /**
+     * Create a new RemoveIndexEvent object for the given wrapped Entity.
+     * The returned Object will be published to the {@link org.springframework.context.ApplicationEventPublisher}.
+     * @param ew the {@link ix.core.util.EntityUtils.EntityWrapper} wrapping the Object that returned {@code true}
+     *           if it was supported by this indexerFactory.
+     * @return the event object to publish; or {@code null} if nothing should be published.
+     */
+    default Object newRemoveEventFor(EntityUtils.EntityWrapper ew){
+        return new IndexRemoveEntityEvent(ew);
+    }
+
+    /**
+     * Does this Factory support this object for indexing?
+     * @param object the object to be indexed; will never be null.
+     * @return {@code true} if it can; {@code false} otherwise.
+     */
+    boolean supports(Object object);
+
+    /**
+     * The sort order to provide when iterating through the list of all
+     * known factories.  The lower the number the earlier in the list it will be.
+     * Do not use the Integer.MAX_VALUE OR {@link Ordered#LOWEST_PRECEDENCE}
+     * as that is reserved for {@link DefaultIndexerEventFactory} so it is always last.
+     * @return an int the lower the earlier this object will appear in Spring sorted autowired lists.
+     */
+    @Override
+    int getOrder();
+}

--- a/gsrs-core-entities/src/main/java/gsrs/indexer/IndexerEventFactoryFactory.java
+++ b/gsrs-core-entities/src/main/java/gsrs/indexer/IndexerEventFactoryFactory.java
@@ -1,0 +1,13 @@
+package gsrs.indexer;
+
+/**
+ * A Factory to get the {@link IndexerEventFactory} for particular Objects.
+ */
+public interface IndexerEventFactoryFactory {
+    /**
+     * Get a {@link IndexerEventFactory} for the given Object to be indexed.
+     * @param o the object o index; will never be null.
+     * @return an IndexerEventFactory; if the returned object is null, then the object should not be indexed.
+     */
+    IndexerEventFactory getIndexerFactoryFor(Object o);
+}

--- a/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/autoconfigure/GsrsApiAutoConfiguration.java
+++ b/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/autoconfigure/GsrsApiAutoConfiguration.java
@@ -1,6 +1,8 @@
 package gsrs.autoconfigure;
 
 import gsrs.EntityProcessorFactory;
+import gsrs.indexer.DefaultIndexerEventFactory;
+import gsrs.indexer.DefaultIndexerEventFactoryFactory;
 import gsrs.security.AdminService;
 import gsrs.security.GsrsSecurityUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,6 +44,8 @@ import org.springframework.transaction.annotation.Transactional;
         IxContext.class,
         LoopbackWebRequestHelper.class,
         HttpLoopBackConfig.class,
+        DefaultIndexerEventFactoryFactory.class,
+        DefaultIndexerEventFactory.class,
 })
 public class GsrsApiAutoConfiguration {
 

--- a/gsrs-spring-legacy-sequence-indexer/src/main/java/gsrs/sequence/indexer/SequenceEntityIndexCreateEvent.java
+++ b/gsrs-spring-legacy-sequence-indexer/src/main/java/gsrs/sequence/indexer/SequenceEntityIndexCreateEvent.java
@@ -1,0 +1,19 @@
+package gsrs.sequence.indexer;
+
+import gsrs.indexer.IndexCreateEntityEvent;
+import ix.core.models.SequenceEntity;
+import ix.core.util.EntityUtils;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SequenceEntityIndexCreateEvent extends IndexCreateEntityEvent {
+    SequenceEntity.SequenceType sequenceType;
+
+    public SequenceEntityIndexCreateEvent(EntityUtils.Key key, SequenceEntity.SequenceType sequenceType) {
+        super(key);
+        this.sequenceType = sequenceType;
+    }
+}

--- a/gsrs-spring-legacy-sequence-indexer/src/main/java/gsrs/sequence/indexer/SequenceEntityUpdateCreateEvent.java
+++ b/gsrs-spring-legacy-sequence-indexer/src/main/java/gsrs/sequence/indexer/SequenceEntityUpdateCreateEvent.java
@@ -1,0 +1,19 @@
+package gsrs.sequence.indexer;
+
+import gsrs.indexer.IndexCreateEntityEvent;
+import gsrs.indexer.IndexUpdateEntityEvent;
+import ix.core.models.SequenceEntity;
+import ix.core.util.EntityUtils;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SequenceEntityUpdateCreateEvent extends IndexUpdateEntityEvent {
+    SequenceEntity.SequenceType sequenceType;
+
+    public SequenceEntityUpdateCreateEvent(EntityUtils.Key key, SequenceEntity.SequenceType sequenceType) {
+        super(key);
+        this.sequenceType = sequenceType;
+    }
+}

--- a/gsrs-spring-legacy-sequence-indexer/src/main/java/gsrs/sequence/indexer/SubunitIndexerEventFactory.java
+++ b/gsrs-spring-legacy-sequence-indexer/src/main/java/gsrs/sequence/indexer/SubunitIndexerEventFactory.java
@@ -1,0 +1,28 @@
+package gsrs.sequence.indexer;
+
+import gsrs.indexer.IndexerEventFactory;
+import ix.core.models.SequenceEntity;
+import ix.core.util.EntityUtils;
+
+public class SubunitIndexerEventFactory implements IndexerEventFactory {
+    @Override
+    public boolean supports(Object object) {
+        return object instanceof SequenceEntity;
+    }
+
+    @Override
+    public Object newCreateEventFor(EntityUtils.EntityWrapper ew) {
+        return new SequenceEntityIndexCreateEvent(ew.getKey(), ((SequenceEntity) ew.getValue()).computeSequenceType());
+
+    }
+
+    @Override
+    public Object newUpdateEventFor(EntityUtils.EntityWrapper ew) {
+        return new SequenceEntityUpdateCreateEvent(ew.getKey(), ((SequenceEntity) ew.getValue()).computeSequenceType());
+    }
+
+    @Override
+    public int getOrder() {
+        return 0;
+    }
+}

--- a/gsrs-spring-legacy-sequence-indexer/src/main/java/gsrs/sequence/search/legacy/GsrsLegacySequenceIndexerSelector.java
+++ b/gsrs-spring-legacy-sequence-indexer/src/main/java/gsrs/sequence/search/legacy/GsrsLegacySequenceIndexerSelector.java
@@ -1,6 +1,7 @@
 package gsrs.sequence.search.legacy;
 
 
+import gsrs.sequence.indexer.SubunitIndexerEventFactory;
 import ix.seqaln.SequenceIndexerEventListener;
 import ix.seqaln.configuration.LegacySequenceAlignmentConfiguration;
 import ix.seqaln.service.LegacySequenceIndexerService;
@@ -11,6 +12,7 @@ public class GsrsLegacySequenceIndexerSelector implements ImportSelector {
     @Override
     public String[] selectImports(AnnotationMetadata annotationMetadata) {
         return new String[]{
+                SubunitIndexerEventFactory.class.getName(),
                 LegacySequenceAlignmentConfiguration.class.getName(),
                 LegacySequenceIndexerService.class.getName(),
                 SequenceIndexerEventListener.class.getName()};

--- a/gsrs-spring-legacy-sequence-indexer/src/main/java/ix/seqaln/SequenceIndexerEventListener.java
+++ b/gsrs-spring-legacy-sequence-indexer/src/main/java/ix/seqaln/SequenceIndexerEventListener.java
@@ -83,19 +83,11 @@ public class SequenceIndexerEventListener {
     @TransactionalEventListener
     public void onCreate(IndexCreateEntityEvent event) {
 
-        if(event instanceof SequenceEntityIndexCreateEvent)return;
+        if(event instanceof SequenceEntityIndexCreateEvent){
+            indexSequencesFor(event.getSource(), ((SequenceEntityIndexCreateEvent)event).getSequenceType());
+        }
         indexSequencesFor(event.getSource(),null);
     }
-
-    @Async
-    @TransactionalEventListener
-    public void onCreate(SequenceEntityIndexCreateEvent event) {
-        indexSequencesFor(event.getSource(), event.getSequenceType());
-    }
-
-//    private boolean couldHaveSequence(Key key) {
-//       return key.getEntityInfo().couldHaveSequenceFields();
-//    }
 
     private void indexSequencesFor(EntityUtils.Key source, SequenceEntity.SequenceType sequenceType) {
         try {

--- a/gsrs-spring-legacy-sequence-indexer/src/main/java/ix/seqaln/SequenceIndexerEventListener.java
+++ b/gsrs-spring-legacy-sequence-indexer/src/main/java/ix/seqaln/SequenceIndexerEventListener.java
@@ -83,13 +83,13 @@ public class SequenceIndexerEventListener {
     @TransactionalEventListener
     public void onCreate(IndexCreateEntityEvent event) {
 
+        if(event instanceof SequenceEntityIndexCreateEvent)return;
         indexSequencesFor(event.getSource(),null);
     }
 
     @Async
     @TransactionalEventListener
     public void onCreate(SequenceEntityIndexCreateEvent event) {
-
         indexSequencesFor(event.getSource(), event.getSequenceType());
     }
 
@@ -162,6 +162,7 @@ public class SequenceIndexerEventListener {
     @Async
     @TransactionalEventListener
     public void onUpdate(IndexUpdateEntityEvent event){
+        if(event instanceof SequenceEntityUpdateCreateEvent)return;
         if(!event.getSource().getEntityInfo().couldHaveSequenceFields()) {
             return;
         }

--- a/gsrs-spring-legacy-sequence-indexer/src/main/java/ix/seqaln/SequenceIndexerEventListener.java
+++ b/gsrs-spring-legacy-sequence-indexer/src/main/java/ix/seqaln/SequenceIndexerEventListener.java
@@ -7,6 +7,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 
+import gsrs.sequence.indexer.SequenceEntityIndexCreateEvent;
+import gsrs.sequence.indexer.SequenceEntityUpdateCreateEvent;
 import org.jcvi.jillion.core.residue.aa.AminoAcid;
 import org.jcvi.jillion.core.residue.aa.ProteinSequence;
 import org.jcvi.jillion.core.residue.nt.Nucleotide;
@@ -70,7 +72,7 @@ public class SequenceIndexerEventListener {
     @EventListener
     public void reindexingEntity(ReindexEntityEvent event) throws IOException {       
         try {
-            addToIndex(event.getOptionalFetchedEntityToReindex().get(), event.getEntityKey());
+            addToIndex(event.getOptionalFetchedEntityToReindex().get(), event.getEntityKey(),null);
         }catch(Exception e) {
            log.warn("Trouble sequence indexing:" + event.getEntityKey(), e);
             
@@ -80,15 +82,22 @@ public class SequenceIndexerEventListener {
     @Async
     @TransactionalEventListener
     public void onCreate(IndexCreateEntityEvent event) {
-        indexSequencesFor(event.getSource());
+
+        indexSequencesFor(event.getSource(),null);
     }
-    
+
+    @Async
+    @TransactionalEventListener
+    public void onCreate(SequenceEntityIndexCreateEvent event) {
+
+        indexSequencesFor(event.getSource(), event.getSequenceType());
+    }
 
 //    private boolean couldHaveSequence(Key key) {
 //       return key.getEntityInfo().couldHaveSequenceFields();
 //    }
 
-    private void indexSequencesFor(EntityUtils.Key source) {
+    private void indexSequencesFor(EntityUtils.Key source, SequenceEntity.SequenceType sequenceType) {
         try {
             if(!source.getEntityInfo().couldHaveSequenceFields()) {
                 return;
@@ -100,7 +109,7 @@ public class SequenceIndexerEventListener {
                     return;
                 }
                 EntityUtils.Key k = ew.getKey();
-                addToIndex(ew, k);
+                addToIndex(ew, k, sequenceType);
             }
         }catch(Exception e) {
            log.warn("Trouble sequence indexing:" + source, e);
@@ -108,24 +117,27 @@ public class SequenceIndexerEventListener {
         }
     }
 
-    private void addToIndex(EntityUtils.EntityWrapper<?> ew, EntityUtils.Key k) {
+    private void addToIndex(EntityUtils.EntityWrapper<?> ew, EntityUtils.Key k, SequenceEntity.SequenceType sequenceType) {
         ew.streamSequenceFieldAndValues(d->true).map(p->p.v()).filter(s->s instanceof String).forEach(str->{
             try {
                 boolean added=false;
                 Object value = ew.getValue();
-                if(value instanceof SequenceEntity){
-                    SequenceEntity.SequenceType type = ((SequenceEntity)value).computeSequenceType();
-                    if(type==SequenceEntity.SequenceType.NUCLEIC_ACID){
+                SequenceEntity.SequenceType type=sequenceType;
+                if(type ==null && value instanceof SequenceEntity){
+                    type = ((SequenceEntity)value).computeSequenceType();
+
+                }
+                if(type==SequenceEntity.SequenceType.NUCLEIC_ACID){
                         added=true;
                         indexer.add(k.getIdString(), NucleotideSequence.of(
                                 Nucleotide.cleanSequence(str.toString(), "N")));
-                    }else if(type==SequenceEntity.SequenceType.PROTEIN) {
-                        added = true;
-                        indexer.add(k.getIdString(), ProteinSequence.of(
-                                AminoAcid.cleanSequence(str.toString(), "X")));
-                    }
-
+                }else if(type==SequenceEntity.SequenceType.PROTEIN) {
+                    added = true;
+                    indexer.add(k.getIdString(), ProteinSequence.of(
+                            AminoAcid.cleanSequence(str.toString(), "X")));
                 }
+
+
                 if(!added){
                     indexer.add(k.getIdString(), str.toString());
                 }
@@ -157,7 +169,20 @@ public class SequenceIndexerEventListener {
         if(ew.isEntity() && ew.hasKey()) {
             EntityUtils.Key key = ew.getKey();
             removeFromIndex(ew, key);
-            addToIndex(ew, key);
+            addToIndex(ew, key,null);
+        }
+    }
+    @Async
+    @TransactionalEventListener
+    public void onUpdate(SequenceEntityUpdateCreateEvent event){
+        if(!event.getSource().getEntityInfo().couldHaveSequenceFields()) {
+            return;
+        }
+        EntityUtils.EntityWrapper ew = event.getSource().fetch().get();
+        if(ew.isEntity() && ew.hasKey()) {
+            EntityUtils.Key key = ew.getKey();
+            removeFromIndex(ew, key);
+            addToIndex(ew, key, event.getSequenceType());
         }
     }
 

--- a/gsrs-spring-starter-tests/src/main/java/gsrs/startertests/GsrsEntityTestConfiguration.java
+++ b/gsrs-spring-starter-tests/src/main/java/gsrs/startertests/GsrsEntityTestConfiguration.java
@@ -5,7 +5,9 @@ import gsrs.GsrsFactoryConfiguration;
 import gsrs.autoconfigure.GsrsApiAutoConfiguration;
 import gsrs.controller.GsrsControllerConfiguration;
 import gsrs.entityProcessor.ConfigBasedEntityProcessorFactory;
+import gsrs.indexer.DefaultIndexerEventFactoryFactory;
 import gsrs.indexer.IndexValueMakerFactory;
+import gsrs.indexer.IndexerEventFactoryFactory;
 import gsrs.validator.GsrsValidatorFactory;
 import ix.core.search.text.Lucene4IndexServiceFactory;
 import ix.core.search.text.TextIndexerConfig;
@@ -56,6 +58,12 @@ public class GsrsEntityTestConfiguration {
     @Primary
     public GsrsValidatorFactory defaultValidatorFactory(){
         return new TestGsrsValidatorFactory();
+    }
+    @Bean
+    @Order
+    @ConditionalOnMissingBean
+    public IndexerEventFactoryFactory indexerEventFactoryFactory(){
+        return new DefaultIndexerEventFactoryFactory();
     }
 }
 


### PR DESCRIPTION
and allow extensible new indexing events.

Short summary:
  before index events were basically all the same a special event for a Creation  event, an update event and a remove event.  creating those event objects was hardcoded.

Now there are factories that support different kinds of entity objects and you can make and register your own factory.  The hibernate event listener will now ask a "factory-factory" to find the appropriate factory that can make the event to publish.

The Sequence indexer has its own special sequence created/updated/removed events now that also passes along the sequencingType.

there is a default factory that is used if no other factory is found so the old default behavior is preserved.