### PR TITLE
Change ScheduledTask to include JobStats

### DIFF
--- a/gsrs-core-entities/src/main/java/gsrs/EditLock.java
+++ b/gsrs-core-entities/src/main/java/gsrs/EditLock.java
@@ -99,7 +99,15 @@ public class EditLock {
     }
 
 
-
+    public boolean acquireIfFree(){
+        synchronized (count){
+            if(count.intValue() ==0){
+                acquire();
+                return true;
+            }
+            return false;
+        }
+    }
     public void acquire() {
         synchronized (count) {
             count.increment();
@@ -179,7 +187,9 @@ public class EditLock {
 
 
 	public int getCount() {
-		return count.intValue();
+        synchronized (count) {
+            return count.intValue();
+        }
 	}
 
     static class LockProxy implements Lock {

--- a/gsrs-scheduled-tasks/src/main/java/gsrs/scheduledTasks/ScheduledTaskInitializer.java
+++ b/gsrs-scheduled-tasks/src/main/java/gsrs/scheduledTasks/ScheduledTaskInitializer.java
@@ -3,8 +3,12 @@ package gsrs.scheduledTasks;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 
+/**
+ * Abstract Class to create ScheduledTasks.
+ *
+ */
 @Data
 public abstract class ScheduledTaskInitializer {
     @JsonProperty("autorun")
@@ -21,11 +25,11 @@ public abstract class ScheduledTaskInitializer {
             .build();
 
 
-    public Consumer<SchedulerPlugin.TaskListener> getRunner(){
+    public BiConsumer<gsrs.scheduledTasks.SchedulerPlugin.JobStats, SchedulerPlugin.TaskListener> getRunner(){
         return this::run;
     }
 
-    public abstract void run(SchedulerPlugin.TaskListener l);
+    public abstract void run(gsrs.scheduledTasks.SchedulerPlugin.JobStats stats, SchedulerPlugin.TaskListener l);
 
     public abstract String getDescription();
 


### PR DESCRIPTION
Merge after HF4 :

GSRS 2 passed in a JobStats object which keeps track of how many times a given scheduledTask has been executed.  Early on in GSRS 3 development JobStats#getNextRun() to compute when the next time it would fire was difficult to compute because it mixed Controller code and dependency injection and POJOs which I didn't want to do.  Also all FDA scheduledTasks didn't need it so I postponed it.  So the easier abstraction of GSRS 3 scheduledTasks did not have JobStats in the method that a scheduledTask had to implement.  Since then, we were able to add the JobStats back once we learned more about how Spring worked.

Now we need JobStats for NCATS/NSRS implementation so I added it back in to the API but this is a API breaking change as the scheduledTask run method now needs 2 parameters instead of 1.  I have fixed all substance scheduledTasks and will push it once this is merged.  No other FDA microservices are affected as they don't have scheduled tasks.