### PR TITLE
Loose Threads

### DIFF
--- a/gsrs-core-entities/src/main/java/gsrs/AuditConfig.java
+++ b/gsrs-core-entities/src/main/java/gsrs/AuditConfig.java
@@ -3,8 +3,10 @@ package gsrs;
 import com.google.common.cache.CacheBuilder;
 import gov.nih.ncats.common.util.Caches;
 import gov.nih.ncats.common.util.TimeUtil;
+import gov.nih.ncats.common.util.Unchecked;
 import gsrs.repository.PrincipalRepository;
 import gsrs.security.GsrsUserProfileDetails;
+import gsrs.security.hasAdminRole;
 import ix.core.models.Principal;
 import lombok.extern.slf4j.Slf4j;
 
@@ -31,6 +33,7 @@ import javax.persistence.PersistenceContext;
 import java.time.temporal.TemporalAccessor;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentMap;
 
@@ -52,7 +55,34 @@ public class AuditConfig {
     @Autowired
     private PlatformTransactionManager platformTransactionManager;
 
-    
+    private static ThreadLocal<Boolean> turnOffAuditing = ThreadLocal.withInitial(()-> Boolean.FALSE);
+
+    /**
+     * Temporarily turn off auditing for while
+     * the given runnable is executed.
+     * This will make hibernate calls to get the current datetime
+     * and current user to return empty Optionals which
+     * should mean hibernate won't update the last edited/created fields.
+     *
+     * Note that because this is done in a threadlocal way just while this
+     * runnable is run any persistent changes should be flushed inside this runnable
+     * otherwise it is likely the calls to get the current editor and datetime
+     * won't be called until AFTER auditing is turned back on.
+     * @param throwingRunnable
+     * @param <E>
+     * @throws E
+     */
+    @hasAdminRole
+    public <E extends Throwable> void disableAuditingFor(Unchecked.ThrowingRunnable<E> throwingRunnable) throws E{
+        Objects.requireNonNull(throwingRunnable);
+        turnOffAuditing.set(Boolean.TRUE);
+        try{
+            throwingRunnable.run();
+        }finally{
+            //is this enough? does a delayed DB flush get run now or could it run after?  should we document to force flush?
+            turnOffAuditing.set(Boolean.FALSE);
+        }
+    }
     @Bean
     public AuditorAware<Principal> createAuditorProvider(PrincipalRepository principalRepository
 //            , @Qualifier(DefaultDataSourceConfig.NAME_ENTITY_MANAGER)  EntityManager em
@@ -64,10 +94,11 @@ public class AuditConfig {
     @Primary
     public DateTimeProvider timeTraveller(){
         return ()-> {
+            if(turnOffAuditing.get().booleanValue()){
+                return Optional.empty();
+            }
+            return Optional.of(TimeUtil.getCurrentLocalDateTime());
 
-            Optional<TemporalAccessor> dt = Optional.of(TimeUtil.getCurrentLocalDateTime());
-
-            return dt;
         };
     }
     @Bean
@@ -75,7 +106,7 @@ public class AuditConfig {
         return new AuditingEntityListener();
     }
 
-    public static class SecurityAuditor implements AuditorAware<Principal> {
+    public class SecurityAuditor implements AuditorAware<Principal> {
         private PrincipalRepository principalRepository;
 
         private PlatformTransactionManager transactionManager;
@@ -102,6 +133,9 @@ public class AuditConfig {
         @Override
         @Transactional
         public Optional<Principal> getCurrentAuditor() {
+            if(turnOffAuditing.get().booleanValue()){
+                return Optional.empty();
+            }
             Authentication auth = SecurityContextHolder.getContext().getAuthentication();
             if(auth ==null || auth instanceof AnonymousAuthenticationToken){
                 return Optional.empty();

--- a/gsrs-core-entities/src/main/java/gsrs/AuditConfig.java
+++ b/gsrs-core-entities/src/main/java/gsrs/AuditConfig.java
@@ -170,7 +170,10 @@ public class AuditConfig {
 
             if(auth instanceof GsrsUserProfileDetails){
                 //refetch from repository because the one from the authentication is "detached"
-                //TODO: does that matter?
+                //katzelda Feb 2022 - we need to keep this find call inside the same transaction
+                //because otherwise when we save a record that needs to get the current user (like in edited by)
+                //we need to have the Principal object in the same hibernate session otherwise the database flush will fail.
+
 //                TransactionTemplate tx = new TransactionTemplate(transactionManager);
 //                tx.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
 //                tx.setReadOnly(true);

--- a/gsrs-core-entities/src/main/java/gsrs/AuditConfig.java
+++ b/gsrs-core-entities/src/main/java/gsrs/AuditConfig.java
@@ -171,10 +171,11 @@ public class AuditConfig {
             if(auth instanceof GsrsUserProfileDetails){
                 //refetch from repository because the one from the authentication is "detached"
                 //TODO: does that matter?
-                TransactionTemplate tx = new TransactionTemplate(transactionManager);
-                tx.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
-                tx.setReadOnly(true);
-                return tx.execute(s->principalRepository.findById(((GsrsUserProfileDetails)auth).getPrincipal().user.id));
+//                TransactionTemplate tx = new TransactionTemplate(transactionManager);
+//                tx.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+//                tx.setReadOnly(true);
+//                return tx.execute(s->principalRepository.findById(((GsrsUserProfileDetails)auth).getPrincipal().user.id));
+                return principalRepository.findById(((GsrsUserProfileDetails)auth).getPrincipal().user.id);
 
             }
             String name = auth.getName();
@@ -207,8 +208,8 @@ public class AuditConfig {
                 if (value.isPresent()) {
                     Principal p = value.get();
                     //I don't think we need to have principal attached?
-                    return value;
-//                return Optional.of(em.contains(p)? p : em.merge(p));
+//                    return value;
+                return Optional.of(em.contains(p)? p : em.merge(p));
                 }
                 return value;
             }catch(Throwable t){

--- a/gsrs-core-entities/src/main/java/gsrs/controller/GsrsControllerConfiguration.java
+++ b/gsrs-core-entities/src/main/java/gsrs/controller/GsrsControllerConfiguration.java
@@ -139,6 +139,9 @@ public class GsrsControllerConfiguration {
     public ResponseEntity<Object> handleBadRequest(Map<String, String> queryParameters) {
        return handleBadRequest(400, queryParameters);
     }
+    public ResponseEntity<Object> handleBadRequest(String message, Map<String, String> queryParameters) {
+        return handleBadRequest(400, message, queryParameters);
+    }
     public ResponseEntity<Object> handleError(Throwable t, Map<String, String> queryParameters) {
         int status = overrideErrorCodeIfNeeded(500, queryParameters);
         return new ResponseEntity<>( getError(t, status), HttpStatus.valueOf(status));

--- a/gsrs-core-entities/src/main/java/gsrs/indexer/IndexerEventFactory.java
+++ b/gsrs-core-entities/src/main/java/gsrs/indexer/IndexerEventFactory.java
@@ -3,6 +3,8 @@ package gsrs.indexer;
 import ix.core.util.EntityUtils;
 import org.springframework.core.Ordered;
 
+import java.util.Optional;
+
 /**
  * Factory to create Indexing events for a given Object.
  * GSRS will have several IndexerEventFactories loaded
@@ -27,7 +29,11 @@ public interface IndexerEventFactory extends Ordered {
      *
      */
     default Object newCreateEventFor(EntityUtils.EntityWrapper ew){
-        return new IndexCreateEntityEvent(ew.getKey());
+        Optional<EntityUtils.Key> optKey = ew.getOptionalKey();
+        if(optKey.isPresent()) {
+            return new IndexCreateEntityEvent(optKey.get());
+        }
+        return null;
     }
     /**
      * Create a new UpdateIndexEvent object for the given wrapped Entity.
@@ -37,7 +43,11 @@ public interface IndexerEventFactory extends Ordered {
      * @return the event object to publish; or {@code null} if nothing should be published.
      */
     default Object newUpdateEventFor(EntityUtils.EntityWrapper ew){
-        return new IndexUpdateEntityEvent(ew.getKey());
+        Optional<EntityUtils.Key> optKey = ew.getOptionalKey();
+        if(optKey.isPresent()) {
+            return new IndexUpdateEntityEvent(optKey.get());
+        }
+        return null;
     }
     /**
      * Create a new RemoveIndexEvent object for the given wrapped Entity.

--- a/gsrs-core-entities/src/main/java/gsrs/security/AdminService.java
+++ b/gsrs-core-entities/src/main/java/gsrs/security/AdminService.java
@@ -60,6 +60,24 @@ public class AdminService {
         }
     }
 
+    /**
+     * Run the given Runnable with the given Authentication.
+     * @param authentication the Authentication to use, if set to {@code null},
+     *                        then it will run as someone not authenticated.
+     * @param runnable the runnable to execute.
+     * @throws NullPointerException if runnable is null.
+     */
+    public void runAs(Authentication authentication, Runnable runnable){
+        Objects.requireNonNull(runnable);
+        Authentication oldAuth = SecurityContextHolder.getContext().getAuthentication();
+        try {
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            runnable.run();
+        } finally {
+            SecurityContextHolder.getContext().setAuthentication(oldAuth);
+        }
+    }
+
     public <E extends Throwable> void runAsCurrentUser(Unchecked.ThrowingRunnable<E> runnable) throws E {
        runAs(SecurityContextHolder.getContext().getAuthentication(), runnable);
     }

--- a/gsrs-core-entities/src/main/java/ix/core/models/Payload.java
+++ b/gsrs-core-entities/src/main/java/ix/core/models/Payload.java
@@ -16,6 +16,7 @@ import java.util.UUID;
 
 @Entity
 @Table(name="ix_core_payload")
+@Indexable(indexed = false)//we don't want this indexed
 public class Payload extends BaseModel {
     @Id
     @GenericGenerator(name = "NullUUIDGenerator", strategy = "ix.ginas.models.generators.NullUUIDGenerator")

--- a/gsrs-core/src/main/java/gsrs/model/GsrsApiAction.java
+++ b/gsrs-core/src/main/java/gsrs/model/GsrsApiAction.java
@@ -23,6 +23,14 @@ public @interface GsrsApiAction {
      */
     String value();
 
+    /**
+     * Should the JSON serialized object be just the url as a String or
+     * if the object should be an Object that contains
+     * both the url field and also
+     *  the HTTP verb type.
+     * @return {@code true} if only the url should be serialized;
+     * {@code false} if the url and verb should be
+     */
     boolean serializeUrlOnly() default false;
     /**
      * The HTTP verb Type; defaults to GET
@@ -40,4 +48,11 @@ public @interface GsrsApiAction {
         HEAD,
         PATCH
     }
+
+    /**
+     * What view classes this Action should be visible for. This should be the same
+     * classes that would normally be put in {@link com.fasterxml.jackson.annotation.JsonView}.
+     * @return an array of Classes, if not set then empty array.
+     */
+    Class<?>[] view() default {};
 }

--- a/gsrs-core/src/main/java/ix/core/EntityMapperOptions.java
+++ b/gsrs-core/src/main/java/ix/core/EntityMapperOptions.java
@@ -31,4 +31,19 @@ public @interface EntityMapperOptions {
      */
     String getSelfRel() default "_self";
 
+    /**
+     * The JsonViews that need to be present
+     * to include the self rel.
+     * @return
+     */
+    Class<?>[] selfRelViews() default {};
+    /**
+     * Name of method of class that provides
+     * the id as a String.  If not set, (or set to {@code ""} then
+     * use the field or method annotated with @Id.
+     * @return the String of the public method name that takes no arguments and returns a String
+     * that is the id.
+     */
+    String idProviderRef() default "";
+
 }

--- a/gsrs-scheduled-tasks/src/main/java/gsrs/scheduledTasks/SchedulerPlugin.java
+++ b/gsrs-scheduled-tasks/src/main/java/gsrs/scheduledTasks/SchedulerPlugin.java
@@ -333,7 +333,7 @@ public class SchedulerPlugin{
             return () -> {
                 if (enabled) {
                     if (check.get()) {
-                        StaticContextAccessor.getBean(AdminService.class).runAs(admin.get(), () -> runNow());
+                        StaticContextAccessor.getBean(AdminService.class).runAs(admin.get(), (Runnable) () -> runNow());
 
                     }
                 }

--- a/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/payload/LegacyPayloadService.java
+++ b/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/payload/LegacyPayloadService.java
@@ -17,6 +17,7 @@ import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Optional;
+import java.util.UUID;
 
 //@Service
 public class LegacyPayloadService implements PayloadService {
@@ -124,7 +125,16 @@ public class LegacyPayloadService implements PayloadService {
         }
         return saveFile;
     }
-
+    @Override
+    @Transactional
+    public Optional<InputStream> getPayloadAsInputStream(UUID payloadId) throws IOException {
+        Optional<Payload> opt = payloadRepository.findById(payloadId);
+        if(opt.isPresent()){
+            //have to return a new empty for generics to work?
+            return Optional.empty();
+        }
+        return getPayloadAsInputStream(opt.get());
+    }
     @Override
     public Optional<InputStream> getPayloadAsInputStream(Payload payload) throws IOException {
         //this is almost the same as getAsFile except we do some different handling of db fetching to inputstream

--- a/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/security/GsrsLogoutHandler.java
+++ b/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/security/GsrsLogoutHandler.java
@@ -32,13 +32,13 @@ public class GsrsLogoutHandler implements LogoutHandler {
     @Override
     @Transactional
     public void logout(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, Authentication authentication) {
-        System.out.println("Logging out, found:" + authentication);
+
         if(authentication instanceof AbstractGsrsAuthenticationToken) {
             UserProfile up = ((AbstractGsrsAuthenticationToken) authentication).getUserProfile();
-            System.out.println("User profile is:" + up);
+
             if(up !=null) {
                 for (Session s : new ArrayList<>(sessionRepository.getActiveSessionsFor(up))) {
-                    System.out.println("Found active session:" + s);
+
                     s.expired = true;
                     s.setIsDirty("expired");
                     sessionRepository.saveAndFlush(s);

--- a/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/security/LoginAndLogoutEventListener.java
+++ b/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/security/LoginAndLogoutEventListener.java
@@ -31,7 +31,6 @@ public class LoginAndLogoutEventListener {
     public void onLogin(AuthenticationSuccessEvent event) {
         UserProfile up = (UserProfile) event.getAuthentication().getPrincipal();
 
-        System.out.println("Logged in user " + up + "  auth = " + event.getAuthentication());
 
         List<Session> sessions = sessionRepository.getActiveSessionsFor(up);
         if(sessions.isEmpty()){

--- a/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/service/PayloadService.java
+++ b/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/service/PayloadService.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Optional;
+import java.util.UUID;
 
 public interface PayloadService {
 
@@ -47,6 +48,7 @@ public interface PayloadService {
     Payload createPayload (String name, String mime, InputStream content, PayloadPersistType persistType) throws IOException;
 
     Optional<InputStream> getPayloadAsInputStream(Payload payload) throws IOException;
+    Optional<InputStream> getPayloadAsInputStream(UUID payloadId) throws IOException;
 
     default Optional<InputStream> getPayloadAsUncompressedInputStream(Payload payload)throws IOException {
         Optional<InputStream> compressed = getPayloadAsInputStream(payload);

--- a/gsrs-spring-boot-autoconfigure/src/main/java/ix/core/validator/Validator.java
+++ b/gsrs-spring-boot-autoconfigure/src/main/java/ix/core/validator/Validator.java
@@ -85,6 +85,18 @@ public interface Validator<T> {
 			@Override
 			public void addMessage(ValidationMessage message, Runnable appyAction) {
 				response.addValidationMessage(message);
+				if(message instanceof GinasProcessingMessage){
+					//backwards compatible fix
+					GinasProcessingMessage gpm = (GinasProcessingMessage) message;
+					if(gpm.suggestedChange && appyAction !=null){
+						appyAction.run();
+					}
+				}else {
+					// I guess always apply change?
+					if (appyAction != null) {
+						appyAction.run();
+					}
+				}
 
 			}
 		});

--- a/gsrs-spring-boot-autoconfigure/src/test/java/gsrs/config/TestFileParserHelper.java
+++ b/gsrs-spring-boot-autoconfigure/src/test/java/gsrs/config/TestFileParserHelper.java
@@ -28,25 +28,27 @@ public class TestFileParserHelper {
 
     @Test
     public void absoluteFilePathWithSetAbsoluteRootShouldBeAbsolute() throws IOException {
+        File myFile = new File("path/to/test");
         FileParser.FileParserBuilder builder = FileParser.builder();
-        File f = builder.absoluteRootPath(new File("/another"))
+        File f = builder.absoluteRootPath(new File("another").getAbsoluteFile())
         .defaultFilePath(null)
-        .suppliedFilePath("/path/to/test")
+        .suppliedFilePath(myFile.getAbsolutePath())
         .build().getFile();
         
-        assertEquals(new File("/path/to/test"), f);
+        assertEquals( myFile.getAbsolutePath(), f.getAbsolutePath());
     }
     
 
     @Test
     public void absoluteFilePathWithSetRelativeRootShouldBeAbsolute() throws IOException {
+        File myFile = new File("path/to/test");
         FileParser.FileParserBuilder builder = FileParser.builder();
-        File f = builder.absoluteRootPath(new File("./another"))
-        .defaultFilePath(null)
-        .suppliedFilePath("/path/to/test")
-        .build().getFile();
-        
-        assertEquals(new File("/path/to/test"), f);
+        File f = builder.absoluteRootPath(new File("another"))
+                .defaultFilePath(null)
+                .suppliedFilePath(myFile.getAbsolutePath())
+                .build().getFile();
+
+        assertEquals( myFile.getAbsolutePath(), f.getAbsolutePath());
     }
     
     

--- a/gsrs-spring-starter-tests/src/test/java/gsrs/startertests/audit/CreateUserFieldTest.java
+++ b/gsrs-spring-starter-tests/src/test/java/gsrs/startertests/audit/CreateUserFieldTest.java
@@ -1,5 +1,6 @@
 package gsrs.startertests.audit;
 
+import gsrs.AuditConfig;
 import gsrs.model.AbstractGsrsEntity;
 import gsrs.repository.PrincipalRepository;
 import gsrs.services.PrincipalService;
@@ -25,7 +26,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.OneToOne;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 @GsrsJpaTest(dirtyMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
@@ -45,6 +46,9 @@ public class CreateUserFieldTest  extends AbstractGsrsJpaEntityJunit5Test {
 
     @Autowired
     private PrincipalService principalService;
+
+    @Autowired
+    private AuditConfig auditConfig;
 
     @BeforeEach
     public void addUserToRepo(){
@@ -72,6 +76,18 @@ public class CreateUserFieldTest  extends AbstractGsrsJpaEntityJunit5Test {
         assertThat(sut.getLastModifiedBy().username).isEqualToIgnoringCase("myUser");
     }
 
+    @Test
+    @WithMockUser(username = "myUser")
+    public void noAuditIntialCreationShouldNotSetCreateDateOrLastModified(){
+        MyEntity sut = new MyEntity();
+        sut.setFoo("myFoo");
+        auditConfig.disableAuditingFor(()->entityManager.persistAndFlush(sut));
+
+
+        assertEquals("myFoo", sut.getFoo());
+        assertNull(sut.getCreatedBy());
+        assertNull(sut.getLastModifiedBy());
+    }
 
 
     @Entity


### PR DESCRIPTION
This PR has lots of changes required for Bulk Loads (which will be a different PR for substances) the main changes include but are not limited to:

1. adding support for the "preserve audit" feature in bulk loads where we keep the old last created by and last edited by.  I added this as an Admin Service so only admins can make this change and it only affects the database updates performed inside the passed in lambda operation.  
2. More improvements to the JSON serialization of controller links to support alternative id routes.  The bulk load objects from 2.x used routes with values passed in from what would now be considered a "flex id lookup" I needed a way to annotate that so the routes would automatically get generated that way and not use the @Id fields.
3. other improvements to the custom JSON serialization so that we could make some custom routes and fields only appear in certain views.
4. Indexing event triggers don't fire if entity doesn't have a valid entityWrapper Key.  This might not be needed now because it was due to a bug in the the ported 2.x code in bulk loading but it will prevent any future similar bugs from causing problems 
5. other odds and ends of helper methods