### PR TITLE
Fasta index

### DIFF
--- a/gsrs-core-entities/src/main/java/gsrs/controller/hateoas/GsrsUnwrappedEntityModelProcessor.java
+++ b/gsrs-core-entities/src/main/java/gsrs/controller/hateoas/GsrsUnwrappedEntityModelProcessor.java
@@ -65,7 +65,7 @@ public class GsrsUnwrappedEntityModelProcessor implements RepresentationModelPro
 
 
     private static boolean shouldInclude(GsrsUnwrappedEntityModel<?> model, Class[] views){
-        if(views ==null){
+        if(views ==null || views.length==0){
             return true;
         }
 

--- a/gsrs-core-entities/src/main/java/gsrs/sequence/SequenceFileSupport.java
+++ b/gsrs-core-entities/src/main/java/gsrs/sequence/SequenceFileSupport.java
@@ -1,0 +1,26 @@
+package gsrs.sequence;
+
+
+import ix.core.models.SequenceEntity;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.stream.Stream;
+
+public interface SequenceFileSupport {
+
+    interface SequenceFileData{
+        enum SequenceFileType{
+            FASTA,
+            //TODO add more formats if needed (fastq, etc)
+            ;
+        }
+        SequenceEntity.SequenceType getSequenceType();
+        SequenceFileType getSequenceFileType();
+        InputStream createInputStream() throws IOException;
+        String getName();
+    }
+    boolean hasSequenceFiles();
+
+    Stream<SequenceFileData> getSequenceFileData();
+}

--- a/gsrs-core-entities/src/main/java/gsrs/sequence/SequenceFileSupport.java
+++ b/gsrs-core-entities/src/main/java/gsrs/sequence/SequenceFileSupport.java
@@ -7,20 +7,70 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.stream.Stream;
 
+/**
+ * An interface that the given entity
+ * can have attached Sequence format files.
+ */
 public interface SequenceFileSupport {
-
+    /**
+     * An Object containing information about an attached Sequence File
+     * and a mechanism to get that data.
+     */
     interface SequenceFileData{
+        /**
+         * The types of supported sequence files.
+         */
         enum SequenceFileType{
+            /**
+             * A FASTA file of either DNA, RNA or protein sequences.
+             */
             FASTA,
             //TODO add more formats if needed (fastq, etc)
             ;
         }
+
+        /**
+         * Get the {@link ix.core.models.SequenceEntity.SequenceType}.
+         * @return
+         */
         SequenceEntity.SequenceType getSequenceType();
+
+        /**
+         * Get the sequence file type which is needed to know
+         * how to interpret the data returned by {@link #createInputStream()}.
+         * @return
+         */
         SequenceFileType getSequenceFileType();
+
+        /**
+         * Get the file data of this sequence file as an InputStream.
+         * @return a new InputStream.
+         * @throws IOException if there is a problem opening the file.
+         */
         InputStream createInputStream() throws IOException;
+
+        /**
+         * Get the file name of this sequence file.
+         * @return the name of the file.
+         */
         String getName();
     }
+
+    /**
+     * Does this entity have any attached sequence files.
+     * From an API perspective this should usually be the same but more efficient
+     * than checking if {@link #getSequenceFileData()} returns a non-empty Stream.
+     *
+     * @return {@code true} if there are attached sequence files;
+     * {@code false} otherwise.  This method does not actually check
+     * that the contents of these files, so while unlikely, it is possible that
+     * there are attached sequence files that contain no sequence data.
+     */
     boolean hasSequenceFiles();
 
+    /**
+     * Get the SequenceFileData for the attached sequence files.
+     * @return
+     */
     Stream<SequenceFileData> getSequenceFileData();
 }

--- a/gsrs-core/src/main/java/ix/core/util/EntityUtils.java
+++ b/gsrs-core/src/main/java/ix/core/util/EntityUtils.java
@@ -1162,14 +1162,14 @@ public class EntityUtils {
 		});
 
 		private CachedSupplier<Boolean> hasPossibleSequence = CachedSupplier.of(()->{
-		    boolean couldHaveSequence = this
-		            .getTypeAndSubTypes()
-		            .stream()
-		            .map(tt->tt.getSequenceFieldInfo())
-		            .filter(tt->tt!=null)
-		            .anyMatch(tt->!tt.isEmpty())
-		            ;
-		    return couldHaveSequence;
+			boolean couldHaveSequence = this
+					.getTypeAndSubTypes()
+					.stream()
+					.map(tt->tt.getSequenceFieldInfo())
+					.filter(tt->tt!=null)
+					.anyMatch(tt->!tt.isEmpty())
+					;
+			return couldHaveSequence;
 		});
 		
 		private boolean isRootIndex=false;
@@ -1254,7 +1254,7 @@ public class EntityUtils {
 		public boolean couldHaveSequenceFields() {
 		    return hasPossibleSequence.get();
 		}
-        
+
 
 		public EntityInfo(Class<T> cls) {
 

--- a/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/payload/LegacyPayloadConfiguration.java
+++ b/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/payload/LegacyPayloadConfiguration.java
@@ -10,6 +10,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Optional;
+import java.util.UUID;
 
 @ConfigurationProperties("ix.core.files.persist")
 @Data
@@ -45,15 +46,18 @@ ix.core.files.persist.maxsize="30MB"
             }
         }
     }
-
     public Optional<File> getExistingFileFor(Payload payload){
-        File temp = new File(base,payload.id.toString());
+        return getExistingFileFor(payload.id);
+    }
+    public Optional<File> getExistingFileFor(UUID payloadId){
+        String uuidAsString = payloadId.toString();
+        File temp = new File(base,uuidAsString);
         if(temp.exists()){
             return Optional.of(temp);
         }
         if(!PERSIST_LOCATION_FILE.equals(location) && ! PERSIST_LOCATION_DB.equals(location) ) {
 
-            File newLoc = new File(location, payload.id.toString());
+            File newLoc = new File(location, uuidAsString);
             if (newLoc.exists()) {
                 return Optional.of(newLoc);
             }

--- a/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/payload/LegacyPayloadConfiguration.java
+++ b/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/payload/LegacyPayloadConfiguration.java
@@ -12,6 +12,10 @@ import java.nio.file.Files;
 import java.util.Optional;
 import java.util.UUID;
 
+/**
+ * Configuration for {@link LegacyPayloadService}
+ * using the GSRS 2.x key-value property files.
+ */
 @ConfigurationProperties("ix.core.files.persist")
 @Data
 public class LegacyPayloadConfiguration {
@@ -46,9 +50,22 @@ ix.core.files.persist.maxsize="30MB"
             }
         }
     }
+
+    /**
+     * Get the file associated with the given payload.
+     * @param payload the payload to look for.
+     * @return an Optional wrapped File if the file is found;
+     * {@link Optional#empty()} if not found.
+     */
     public Optional<File> getExistingFileFor(Payload payload){
         return getExistingFileFor(payload.id);
     }
+    /**
+     * Get the file associated with the given payload UUID.
+     * @param payloadId the UUID of the payload to look for.
+     * @return an Optional wrapped File if the file is found;
+     * {@link Optional#empty()} if not found.
+     */
     public Optional<File> getExistingFileFor(UUID payloadId){
         String uuidAsString = payloadId.toString();
         File temp = new File(base,uuidAsString);
@@ -64,6 +81,17 @@ ix.core.files.persist.maxsize="30MB"
         }
         return Optional.empty();
     }
+
+    /**
+     * Create a new PERSIST File for the given Payload,
+     * the returned File will not contain any data and might not even
+     * be created yet but you should use this File to write the data for this payload.
+     * the Persist File is a more permanent file location
+     * @param payload the payload to associate the file to; can not be null and should have a non-null id.
+     * @return an Optional wrapped File of the file associated; or {@link Optional#empty()}
+     * if a file location could not be used.
+     * @throws IOException if there is a problem creating the directory structure for this file.
+     */
     public Optional<File> createNewPersistFileFor(Payload payload) throws IOException{
         if(PERSIST_LOCATION_FILE.equals(location) ||PERSIST_LOCATION_DB.equals(location) ){
             return Optional.empty();
@@ -76,12 +104,4 @@ ix.core.files.persist.maxsize="30MB"
         return Optional.of(newLoc);
 
     }
-
-//    @Bean
-//    @ConditionalOnMissingBean
-//    public PayloadService legacyPayloadService(PayloadRepository payloadRepository,
-//                                                      LegacyPayloadConfiguration configuration, FileDataRepository fileDataRepository) throws IOException {
-//
-//        return new LegacyPayloadService(payloadRepository, configuration, fileDataRepository);
-//    }
 }

--- a/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/payload/LegacyPayloadService.java
+++ b/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/payload/LegacyPayloadService.java
@@ -91,7 +91,7 @@ public class LegacyPayloadService implements PayloadService {
         //TODO does this belong here or in the configuration? maybe here? and make the configuration object a thin model?
         File saveFile = configuration.createNewSaveFileFor(payload);
         Files.move(tmpFile.toPath(), saveFile.toPath(), StandardCopyOption.ATOMIC_MOVE);
-        tmpFile.renameTo(saveFile);
+//        tmpFile.renameTo(saveFile);
 
         //database persist
         if(ptype==PayloadPersistType.PERM){
@@ -129,7 +129,7 @@ public class LegacyPayloadService implements PayloadService {
     @Transactional
     public Optional<InputStream> getPayloadAsInputStream(UUID payloadId) throws IOException {
         Optional<Payload> opt = payloadRepository.findById(payloadId);
-        if(opt.isPresent()){
+        if(!opt.isPresent()){
             //have to return a new empty for generics to work?
             return Optional.empty();
         }

--- a/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/payload/LegacyPayloadService.java
+++ b/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/payload/LegacyPayloadService.java
@@ -19,7 +19,12 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Optional;
 import java.util.UUID;
 
-//@Service
+/**
+ * Payload Service implementation that uses the legacy
+ * GSRS 2.x Payload table and payload folder under the
+ * ginas home directory to save and return Files.
+ */
+
 public class LegacyPayloadService implements PayloadService {
 
     private final PayloadRepository payloadRepository;
@@ -91,7 +96,6 @@ public class LegacyPayloadService implements PayloadService {
         //TODO does this belong here or in the configuration? maybe here? and make the configuration object a thin model?
         File saveFile = configuration.createNewSaveFileFor(payload);
         Files.move(tmpFile.toPath(), saveFile.toPath(), StandardCopyOption.ATOMIC_MOVE);
-//        tmpFile.renameTo(saveFile);
 
         //database persist
         if(ptype==PayloadPersistType.PERM){

--- a/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/payload/LegacyPayloadService.java
+++ b/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/payload/LegacyPayloadService.java
@@ -128,9 +128,13 @@ public class LegacyPayloadService implements PayloadService {
     @Override
     @Transactional
     public Optional<InputStream> getPayloadAsInputStream(UUID payloadId) throws IOException {
+        Optional<File> existingFile = configuration.getExistingFileFor(payloadId);
+        if(existingFile.isPresent()){
+            return Optional.of(new FileInputStream(existingFile.get()));
+        }
+        //if we can't find it look in db
         Optional<Payload> opt = payloadRepository.findById(payloadId);
         if(!opt.isPresent()){
-            //have to return a new empty for generics to work?
             return Optional.empty();
         }
         return getPayloadAsInputStream(opt.get());

--- a/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/payload/PayloadController.java
+++ b/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/payload/PayloadController.java
@@ -38,6 +38,10 @@ import gsrs.service.PayloadService;
 import gsrs.springUtils.StaticContextAccessor;
 import ix.core.models.Payload;
 
+/**
+ * Controller for {@link Payload} data
+ * to match GSRS 2.x API.
+ */
 @ExposesResourceFor(Payload.class)
 //not plural so it matches context from GSRS 2.x
 @GsrsRestApiController(context="payload")
@@ -60,11 +64,6 @@ public class PayloadController{
    
             Payload payload = payloadService.createPayload(file.getOriginalFilename(), predictMimeTypeFromFile(file), file.getBytes(), PayloadService.PayloadPersistType.PERM);
 
-
-            //This is a very hacky way to force things as expected
-//            Link l1=  StaticContextAccessor.getBean(GsrsUnwrappedEntityModelProcessor.class).computeSelfLink(unwrapped, payload.id.toString());
-//            payload.url=l1.getHref() + "&format=raw";
-//
             //OK to match GSRS 2.x API
             return new ResponseEntity<>(GsrsControllerUtil.enhanceWithView(payload, queryParameters), HttpStatus.OK);
     }

--- a/gsrs-spring-legacy-sequence-indexer/src/main/java/ix/seqaln/SequenceIndexer.java
+++ b/gsrs-spring-legacy-sequence-indexer/src/main/java/ix/seqaln/SequenceIndexer.java
@@ -908,7 +908,6 @@ public class SequenceIndexer {
 
                       Result cachedResult= _cachedResults.computeIfAbsent(tseq, k -> {
                           Result r = new Result(entry.getKey().s, querySeq.toString(), tseq);
-                          System.out.println("result r key.s = " + entry.getKey().s);
                           r.setScore(-1, rt);
                                   try {
 

--- a/gsrs-spring-legacy-sequence-indexer/src/main/java/ix/seqaln/SequenceIndexer.java
+++ b/gsrs-spring-legacy-sequence-indexer/src/main/java/ix/seqaln/SequenceIndexer.java
@@ -44,6 +44,10 @@ import java.util.stream.Collectors;
 import static org.apache.lucene.document.Field.Store.NO;
 import static org.apache.lucene.document.Field.Store.YES;
 
+/**
+ * A lucene based index of genomic sequences
+ * with methods to add/remove and perform alignments.
+ */
 @Slf4j
 public class SequenceIndexer {
     static final String CACHE_NAME = SequenceIndexer.class.getName()+".Cache";
@@ -76,34 +80,6 @@ public class SequenceIndexer {
         }
     }
 
-    static class HSP implements Comparable<HSP> {
-        public String kmer;
-        public int i, j;
-
-        HSP (String kmer, int i, int j) {
-            this.kmer = kmer;
-            this.i = i;
-            this.j = j;
-        }
-        public int gap () { return Math.abs(i - j); }
-        public String toString () { return kmer+"["+i+","+j+"]"; }
-        public int compareTo (HSP hsp) {
-            int d = hsp.kmer.length() - kmer.length();
-            if (d == 0) {
-                d = gap () - hsp.gap();
-            }
-            if (d == 0) {
-                d = i - hsp.i;
-            }
-            if (d == 0) {
-                d = j - hsp.j;
-            }
-            if (d == 0) {
-                d = kmer.compareTo(hsp.kmer);
-            }
-            return d;
-        }
-    }
 
     public static class SEG implements Comparable<SEG>, Serializable {
         /**

--- a/gsrs-spring-legacy-sequence-indexer/src/main/java/ix/seqaln/SequenceIndexer.java
+++ b/gsrs-spring-legacy-sequence-indexer/src/main/java/ix/seqaln/SequenceIndexer.java
@@ -39,7 +39,6 @@ import java.io.Serializable;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.apache.lucene.document.Field.Store.NO;
@@ -876,6 +875,7 @@ public class SequenceIndexer {
 	            for (int i = 0; i < docs.totalHits; ++i) {
 	                Document doc = kmerSearcher.doc(docs.scoreDocs[i].doc);
 	                final String id = doc.get(FIELD_ID);
+
 	                StringAndDouble sd = StringAndDouble.from(id, 0);
 		                seqMap.computeIfAbsent(sd, k->getSeq(k.s));
 		            }
@@ -908,6 +908,7 @@ public class SequenceIndexer {
 
                       Result cachedResult= _cachedResults.computeIfAbsent(tseq, k -> {
                           Result r = new Result(entry.getKey().s, querySeq.toString(), tseq);
+                          System.out.println("result r key.s = " + entry.getKey().s);
                           r.setScore(-1, rt);
                                   try {
 
@@ -920,9 +921,8 @@ public class SequenceIndexer {
                                           log.warn("trouble performing alignment for sequence", e);
                                           return r;
                                       }
-                                      long start=System.nanoTime();
                                       PairwiseSequenceAlignment alignment = alignmentHelper.align(querySeq, targetSeq, gap, rt);
-                                      long end=System.nanoTime();
+
                                       
                                       r.setScore(alignment.getPercentIdentity(), rt);
 

--- a/gsrs-spring-legacy-sequence-indexer/src/main/java/ix/seqaln/SequenceIndexer.java
+++ b/gsrs-spring-legacy-sequence-indexer/src/main/java/ix/seqaln/SequenceIndexer.java
@@ -280,8 +280,19 @@ public class SequenceIndexer {
         public final List<Alignment> alignments = new ArrayList<Alignment>();
         public double score;
         public CutoffType scoreType;
-        
 
+        /**
+         * Create a new Result object with the same
+         * fields except a new id.
+         * @param newId
+         * @return
+         */
+        public Result copyWithNewId(String newId){
+            Result resultCopy=new Result(newId,query,target);
+            resultCopy.alignments.addAll(alignments);
+            resultCopy.setScore(score, scoreType);
+            return resultCopy;
+        }
         Result () {
             query = null;
             id = null;
@@ -1040,10 +1051,8 @@ public class SequenceIndexer {
                       //we have to make a copy with the  correct ID of the substance we are aligning
                   //but we can re-use the alignments
 
-                          Result resultCopy=new Result(entry.getKey().s,cachedResult.query,cachedResult.target);
-	              		resultCopy.alignments.addAll(cachedResult.alignments);
-	              		resultCopy.setScore(cachedResult.score,cachedResult.scoreType);
-	              		return resultCopy;
+
+	              		return cachedResult.copyWithNewId(entry.getKey().s);
 
                       }
 

--- a/gsrs-spring-legacy-sequence-indexer/src/main/java/ix/seqaln/SequenceIndexerEventListener.java
+++ b/gsrs-spring-legacy-sequence-indexer/src/main/java/ix/seqaln/SequenceIndexerEventListener.java
@@ -125,6 +125,12 @@ public class SequenceIndexerEventListener {
         }
     }
 
+    /**
+     * Add any sequences from referenced sequence files.  This is where those
+     * sequence files are parsed.
+     * @param source
+     * @param entitySupplier
+     */
     private void addSequenceFileDataToIndex(EntityUtils.Key source, CachedSupplier<Optional<EntityUtils.EntityWrapper<?>>> entitySupplier) {
        if(SequenceFileSupport.class.isAssignableFrom(source.getEntityInfo().getEntityClass())){
             Optional<EntityUtils.EntityWrapper<?>> opt = entitySupplier.get();

--- a/gsrs-spring-legacy-sequence-indexer/src/main/java/ix/seqaln/SequenceIndexerEventListener.java
+++ b/gsrs-spring-legacy-sequence-indexer/src/main/java/ix/seqaln/SequenceIndexerEventListener.java
@@ -1,41 +1,36 @@
 package ix.seqaln;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
-
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
+import java.util.stream.Stream;
 
 import com.google.common.util.concurrent.Striped;
+import gov.nih.ncats.common.util.CachedSupplier;
+import gsrs.sequence.SequenceFileSupport;
 import gsrs.sequence.indexer.SequenceEntityIndexCreateEvent;
 import gsrs.sequence.indexer.SequenceEntityUpdateCreateEvent;
 import org.jcvi.jillion.core.residue.aa.AminoAcid;
 import org.jcvi.jillion.core.residue.aa.ProteinSequence;
 import org.jcvi.jillion.core.residue.nt.Nucleotide;
 import org.jcvi.jillion.core.residue.nt.NucleotideSequence;
+import org.jcvi.jillion.fasta.*;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 
-import com.fasterxml.jackson.databind.JsonNode;
-
-import gsrs.DataSourceConfigRegistry;
-import gsrs.DefaultDataSourceConfig;
 import gsrs.events.MaintenanceModeEvent;
 import gsrs.events.ReindexEntityEvent;
 import gsrs.indexer.IndexCreateEntityEvent;
 import gsrs.indexer.IndexRemoveEntityEvent;
 import gsrs.indexer.IndexUpdateEntityEvent;
 import gsrs.springUtils.GsrsSpringUtils;
-import gsrs.springUtils.StaticContextAccessor;
 import ix.core.models.SequenceEntity;
 import ix.core.util.EntityUtils;
-import ix.core.util.EntityUtils.Key;
 import ix.seqaln.service.SequenceIndexerService;
 import lombok.extern.slf4j.Slf4j;
 
@@ -74,11 +69,14 @@ public class SequenceIndexerEventListener {
     }
 
     @EventListener
-    public void reindexingEntity(ReindexEntityEvent event) throws IOException {       
+    public void reindexingEntity(ReindexEntityEvent event) throws IOException {
+        EntityUtils.Key entityKey = event.getEntityKey();
         try {
-            addToIndex(event.getOptionalFetchedEntityToReindex().get(), event.getEntityKey(),null);
+            EntityUtils.EntityWrapper<?> ew = event.getOptionalFetchedEntityToReindex().get();
+            addSequenceFieldDataToIndex(ew, entityKey,null);
+            addSequenceFileDataToIndex(entityKey, CachedSupplier.of(()->Optional.of(ew) ));
         }catch(Exception e) {
-           log.warn("Trouble sequence indexing:" + event.getEntityKey(), e);
+           log.warn("Trouble sequence indexing:" + entityKey, e);
             
         }
     }
@@ -89,31 +87,113 @@ public class SequenceIndexerEventListener {
 
         if(event instanceof SequenceEntityIndexCreateEvent){
             indexSequencesFor(event.getSource(), ((SequenceEntityIndexCreateEvent)event).getSequenceType());
+        }else {
+            indexSequencesFor(event.getSource(), null);
         }
-        indexSequencesFor(event.getSource(),null);
     }
 
     private void indexSequencesFor(EntityUtils.Key source, SequenceEntity.SequenceType sequenceType) {
         try {
-            if(!source.getEntityInfo().couldHaveSequenceFields()) {
-                return;
-            }
-            Optional<EntityUtils.EntityWrapper<?>> opt= source.fetch();
-            if(opt.isPresent()) {
-                EntityUtils.EntityWrapper<?> ew = opt.get();
-                if (!ew.isEntity() || !ew.hasKey()) {
-                    return;
+            //fetch might be an expensive operation so wrap it in a cachedSupplier
+            //since we might call this more than once now
+            CachedSupplier<Optional<EntityUtils.EntityWrapper<?>>> entitySupplier = CachedSupplier.of(source::fetch);
+
+            if(source.getEntityInfo().couldHaveSequenceFields()) {
+                Optional<EntityUtils.EntityWrapper<?>> opt =entitySupplier.get();
+                if(opt.isPresent()) {
+                    EntityUtils.EntityWrapper<?> ew = opt.get();
+                    if (ew.isEntity()){
+                        Optional<EntityUtils.Key> optKey = ew.getOptionalKey();
+                        if(optKey.isPresent()) {
+                            EntityUtils.Key k = ew.getKey();
+                            addSequenceFieldDataToIndex(ew, k, sequenceType);
+                        }
+
+                    }
                 }
-                EntityUtils.Key k = ew.getKey();
-                addToIndex(ew, k, sequenceType);
             }
+            addSequenceFileDataToIndex(source, entitySupplier);
+
         }catch(Exception e) {
            log.warn("Trouble sequence indexing:" + source, e);
             
         }
     }
 
-    private void addToIndex(EntityUtils.EntityWrapper<?> ew, EntityUtils.Key k, SequenceEntity.SequenceType sequenceType) {
+    private void addSequenceFileDataToIndex(EntityUtils.Key source, CachedSupplier<Optional<EntityUtils.EntityWrapper<?>>> entitySupplier) {
+       if(SequenceFileSupport.class.isAssignableFrom(source.getEntityInfo().getEntityClass())){
+            Optional<EntityUtils.EntityWrapper<?>> opt = entitySupplier.get();
+            if(opt.isPresent()) {
+                EntityUtils.EntityWrapper<?> ew = opt.get();
+                SequenceFileSupport sequenceFileSupport = (SequenceFileSupport) ew.getValue();
+                Object objectId = ew.getId().get();
+                try(Stream<SequenceFileSupport.SequenceFileData> stream = sequenceFileSupport.getSequenceFileData()){
+                    stream
+                            .peek(s-> System.out.println(s))
+                            .forEach( sfd->{
+                        //in unlikely event there are different types in different files
+                        SequenceEntity.SequenceType sequenceTypeForFile=  sfd.getSequenceType();
+                        //TODO if we add more file types change this to a switch or some kind of factory type lookup
+                        //to convert from a type into something that knows how to parse the file
+                        if(SequenceFileSupport.SequenceFileData.SequenceFileType.FASTA == sfd.getSequenceFileType()){
+                            try(InputStream in = sfd.createInputStream()){
+                                FastaParser fastaParser = FastaFileParser.create(in);
+                                fastaParser.parse(new FastaVisitor() {
+                                    @Override
+                                    public FastaRecordVisitor visitDefline(FastaVisitorCallback fastaVisitorCallback, String id, String comment) {
+                                        //TODO process comments
+                                        return new AbstractFastaRecordVisitor(id, comment) {
+                                            @Override
+                                            protected void visitRecord(String id, String comment, String seq) {
+
+
+                                                try {
+                                                    if (sequenceTypeForFile == SequenceEntity.SequenceType.NUCLEIC_ACID) {
+
+                                                        indexer.add(">" + objectId + "|" + id, NucleotideSequence.of(
+                                                                Nucleotide.cleanSequence(seq, "N")));
+                                                    } else if (sequenceTypeForFile == SequenceEntity.SequenceType.PROTEIN) {
+
+                                                        indexer.add(">" + objectId + "|" + id, ProteinSequence.of(
+                                                                AminoAcid.cleanSequence(seq, "X")));
+                                                    }else{
+                                                        indexer.add(">" + objectId + "|" + id, seq);
+                                                    }
+                                                } catch (IOException e) {
+                                                    e.printStackTrace();
+                                                }
+
+
+                                            }
+                                        };
+                                    }
+
+                                    @Override
+                                    public void visitEnd() {
+
+                                    }
+
+                                    @Override
+                                    public void halted() {
+
+                                    }
+                                });
+
+
+
+                            }catch(IOException e){
+                                e.printStackTrace();
+                            }
+                        }
+
+                    });
+                }
+
+            }
+        }
+    }
+
+    private void addSequenceFieldDataToIndex(EntityUtils.EntityWrapper<?> ew, EntityUtils.Key k, SequenceEntity.SequenceType sequenceType) {
         Lock l = stripedLock.get(ew.getKey());
         l.lock();
         try {
@@ -175,7 +255,7 @@ public class SequenceIndexerEventListener {
             l.lock();
             try {
                 removeFromIndex(ew, key);
-                addToIndex(ew, key, null);
+                addSequenceFieldDataToIndex(ew, key, null);
             }finally{
                 l.unlock();
             }
@@ -191,7 +271,7 @@ public class SequenceIndexerEventListener {
         if(ew.isEntity() && ew.hasKey()) {
             EntityUtils.Key key = ew.getKey();
             removeFromIndex(ew, key);
-            addToIndex(ew, key, event.getSequenceType());
+            addSequenceFieldDataToIndex(ew, key, event.getSequenceType());
         }
     }
 

--- a/gsrs-spring-legacy-sequence-indexer/src/main/java/ix/seqaln/SequenceIndexerEventListener.java
+++ b/gsrs-spring-legacy-sequence-indexer/src/main/java/ix/seqaln/SequenceIndexerEventListener.java
@@ -174,7 +174,7 @@ public class SequenceIndexerEventListener {
                                                                     indexer.add(">" + objectId + "|" +fastaFilename+"|"+ id, seq);
                                                                 }
                                                             } catch (IOException e) {
-                                                                e.printStackTrace();
+                                                                log.warn("Trouble FASTA sequence indexing:" + id, e);   
                                                             }
 
 
@@ -195,7 +195,7 @@ public class SequenceIndexerEventListener {
 
 
                                         } catch (IOException e) {
-                                            e.printStackTrace();
+                                            log.warn("Trouble FASTA sequence indexing:" + source.toString(), e);   
                                         }
                                     }
 


### PR DESCRIPTION
This is the starter update to allow for sequence searching attached fasta files.  This follows the same concept as GSRS 2.x but much improved (I don't think 2.x worked after re-indexing, but this does).


  * the entity must implement a new interface `SequenceFileSupport` NucleicAcidSubstance and ProteinSubstance now implement this interface (in separate substance PR)
  
  The Sequence Indexer Event Listener now knows when an entity is indexed or re-indexed to check for  this new SequenceFileSupport interface and if it implements it call the interface method to pull the fasta file and parse it and index it.
  
  How that entity knows how or where the fasta data is is left to the implementation ( see the Substance PR to see how Substances will do with with references).  This allows us to change it for other entities or microservices without changing the starter.

Those fasta file indexed sequences are added to the index using a special naming pattern so that on sequence searches we can better format the alignment information to say it came from record with id X from such and such file.