### PR TITLE
Fix special character handling in query behavior

### DIFF
--- a/gsrs-core-entities/src/main/java/gsrs/controller/hateoas/IxContext.java
+++ b/gsrs-core-entities/src/main/java/gsrs/controller/hateoas/IxContext.java
@@ -51,6 +51,14 @@ public class IxContext {
         }else {
             url= req.getRequestURL().toString() + "?" + req.getQueryString();
         }
+        url=url.replace("^", "%5E")
+                .replace("<", "%3C")
+                .replace(">", "%3E")
+                .replace("[", "%5B")
+                .replace("]", "%5D")
+                .replace("{", "%7B")
+                .replace("}", "%7D")
+                .replace("`", "%60");
         return getEffectiveAdaptedURI(URI.create(url));
     }
     

--- a/gsrs-core/pom.xml
+++ b/gsrs-core/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.9.9</version>
+            <version>2.13.2</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
This does 2 things:

GSRS-2449 :Allow searches that contain "^" to not error out
GSRS-2495: do not show exact search results for cases with wildcards embedded in the query