### PR TITLE
Overide LOB Types registration

### DIFF
--- a/gsrs-core/src/main/java/gsrs/repository/sql/dialect/GSRSPostgreSQLDialectCustom.java
+++ b/gsrs-core/src/main/java/gsrs/repository/sql/dialect/GSRSPostgreSQLDialectCustom.java
@@ -1,6 +1,6 @@
 package gsrs.repository.sql.dialect;
 
-import org.hibernate.dialect.PostgreSQLDialect;
+import org.hibernate.dialect.PostgreSQL9Dialect;
 import org.hibernate.type.descriptor.sql.BinaryTypeDescriptor;
 import org.hibernate.type.descriptor.sql.LongVarcharTypeDescriptor;
 import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
@@ -8,7 +8,7 @@ import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
 /*
 Designed by Tyler Peryea
 */
-public class GSRSPostgreSQLDialectCustom extends PostgreSQLDialect {
+public class GSRSPostgreSQLDialectCustom extends PostgreSQL9Dialect {
 
     public GSRSPostgreSQLDialectCustom() {
         super();

--- a/gsrs-core/src/main/java/gsrs/repository/sql/dialect/GSRSPostgreSQLDialectCustom.java
+++ b/gsrs-core/src/main/java/gsrs/repository/sql/dialect/GSRSPostgreSQLDialectCustom.java
@@ -1,6 +1,6 @@
 package gsrs.repository.sql.dialect;
 
-import org.hibernate.dialect.PostgreSQL9Dialect;
+import org.hibernate.dialect.PostgreSQLDialect;
 import org.hibernate.type.descriptor.sql.BinaryTypeDescriptor;
 import org.hibernate.type.descriptor.sql.LongVarcharTypeDescriptor;
 import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
@@ -8,14 +8,22 @@ import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
 /*
 Designed by Tyler Peryea
 */
-public class GSRSPostgreSQLDialectCustom extends PostgreSQL9Dialect {   
-	@Override
+public class GSRSPostgreSQLDialectCustom extends PostgreSQLDialect {
+
+    public GSRSPostgreSQLDialectCustom() {
+        super();
+
+        registerColumnType(java.sql.Types.BLOB, "bytea");
+        registerColumnType(java.sql.Types.CLOB, "text");
+    }
+
+    @Override
     public SqlTypeDescriptor remapSqlTypeDescriptor(SqlTypeDescriptor sqlTypeDescriptor) {
-    if (sqlTypeDescriptor.getSqlType() == java.sql.Types.BLOB) {
-      return BinaryTypeDescriptor.INSTANCE;
-    }else if (sqlTypeDescriptor.getSqlType() == java.sql.Types.CLOB) {
-      return LongVarcharTypeDescriptor.INSTANCE;
-	}
-    return super.remapSqlTypeDescriptor(sqlTypeDescriptor);
-  }
- }
+        if (sqlTypeDescriptor.getSqlType() == java.sql.Types.BLOB) {
+            return BinaryTypeDescriptor.INSTANCE;
+        }else if (sqlTypeDescriptor.getSqlType() == java.sql.Types.CLOB) {
+            return LongVarcharTypeDescriptor.INSTANCE;
+        }
+        return super.remapSqlTypeDescriptor(sqlTypeDescriptor);
+    }
+}


### PR DESCRIPTION
This PR will fix the Postgres database initialization. The 'bytea' type will be used for BLOBs and 'text' type will be used for CLOBs.