### PR TITLE
GSRS-1783 Remove CutoffType LOCAL

### DIFF
--- a/gsrs-spring-legacy-sequence-indexer/src/main/java/ix/seqaln/SequenceIndexer.java
+++ b/gsrs-spring-legacy-sequence-indexer/src/main/java/ix/seqaln/SequenceIndexer.java
@@ -66,7 +66,7 @@ public class SequenceIndexer {
     });
 
     public static enum CutoffType{
-        LOCAL,
+//        LOCAL,
         GLOBAL,
         SUB;
 


### PR DESCRIPTION
Thanks to the valueOfOrDefault() function in the enum definition, now a "LOCAL" as cutoff type will have the default "GLOBAL" value.