### PR TITLE
fixMySQLdbInitialization

### DIFF
--- a/gsrs-controlled-vocabulary/src/main/java/ix/ginas/models/v1/VocabularyTerm.java
+++ b/gsrs-controlled-vocabulary/src/main/java/ix/ginas/models/v1/VocabularyTerm.java
@@ -50,16 +50,16 @@ public class VocabularyTerm extends IxModel {
 	};
 
 	private static final long serialVersionUID = -5625533710493695789L;
-	@Column(length=4000)
+	@Column(length=3000)
 	public String value;
 
-	@Column(length=4000)
+	@Column(length=3000)
 	public String display;
 
 	@Column(length=4000)
 	public String description;
 
-	@Column(length=4000)
+	@Column(length=3000)
 	public String regex;
 
 	public String origin;


### PR DESCRIPTION
This PR solves database initialization problem on MySQL/MariaDB. It reduce the column lenghts to fit maximal row-size value (64KB) for MySQL/MariaDB databases.