### PR TITLE
make CVs forcable

### DIFF
--- a/gsrs-controlled-vocabulary/src/main/java/ix/ginas/models/v1/ControlledVocabulary.java
+++ b/gsrs-controlled-vocabulary/src/main/java/ix/ginas/models/v1/ControlledVocabulary.java
@@ -27,7 +27,7 @@ import java.util.List;
 @Getter
 @Setter
 @SequenceGenerator(name = "LONG_SEQ_ID", sequenceName = "ix_ginas_controlled_vocab_seq", allocationSize = 1)
-public class ControlledVocabulary extends IxModel {
+public class ControlledVocabulary extends IxModel implements ForceUpdatableModel {
 
     private static final long serialVersionUID = 5455592961232451608L;
 
@@ -140,6 +140,12 @@ public class ControlledVocabulary extends IxModel {
     public void setDomain(String domain) {
         this.domain = domain;
         setIsDirty("domain");
+    }
+
+    @Override
+    public void forceUpdate() {
+        // TODO Auto-generated method stub
+        this.setIsAllDirty();
     }
 
 

--- a/gsrs-controlled-vocabulary/src/main/java/ix/ginas/models/v1/VocabularyTerm.java
+++ b/gsrs-controlled-vocabulary/src/main/java/ix/ginas/models/v1/VocabularyTerm.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import ix.core.SingleParent;
+import ix.core.models.ForceUpdatableModel;
 import ix.core.models.IxModel;
 import ix.core.models.ParentReference;
 import ix.ginas.models.EmbeddedKeywordList;
@@ -26,7 +27,7 @@ import javax.persistence.*;
 @Getter
 @Setter
 @SequenceGenerator(name = "LONG_SEQ_ID", sequenceName = "ix_ginas_vocabulary_term_seq", allocationSize = 1)
-public class VocabularyTerm extends IxModel {
+public class VocabularyTerm extends IxModel implements ForceUpdatableModel{
 	/**
 	 * 
 	 */
@@ -101,5 +102,11 @@ public class VocabularyTerm extends IxModel {
 				", selected=" + selected +
 				"} " + super.toString();
 	}
+
+
+    @Override
+    public void forceUpdate() {
+        this.setIsAllDirty();
+    }
 
 }


### PR DESCRIPTION
It's an oversight that we didn't make CV objects implement ForceUpdatableModel. Since they don't, API-based updates (PUTs) don't properly capture the deep changes that have happened to objects. This means that you can typically add and perhaps remove terms but can't change them. Adding this extra forceUpdate method that lets all objects in the tree get flagged as dirty when they need to be should allow updates.