### PR TITLE
allow restricted searches to identifiers

### DIFF
--- a/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/GsrsFactoryConfiguration.java
+++ b/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/GsrsFactoryConfiguration.java
@@ -1,29 +1,38 @@
 package gsrs;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import gsrs.entityProcessor.EntityProcessorConfig;
-import gsrs.validator.ValidatorConfig;
-import gsrs.validator.ValidatorConfigList;
-import lombok.Data;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.stereotype.Component;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import gsrs.entityProcessor.EntityProcessorConfig;
+import gsrs.validator.ValidatorConfig;
+import lombok.Data;
 @Component
 @ConfigurationProperties("gsrs")
 @Data
 public class GsrsFactoryConfiguration {
 
     private Map<String, List<Map<String,Object>>> validators;
+    
+    private Map<String, Map<String,Object>> search;
+        
     private List<EntityProcessorConfig> entityProcessors;
 
     private boolean createUnknownUsers= false;
 
+    public Optional<Map<String,Object>> getSearchSettingsFor(String context){
+        if(search==null)return Optional.empty();
+        return Optional.ofNullable(search.get(context));
+    }
+    
     public List<EntityProcessorConfig> getEntityProcessors(){
         if(entityProcessors ==null){
             //nothing set

--- a/gsrs-spring-legacy-indexer/src/main/java/ix/core/search/SearchOptions.java
+++ b/gsrs-spring-legacy-indexer/src/main/java/ix/core/search/SearchOptions.java
@@ -84,6 +84,7 @@ public class SearchOptions implements RequestOptions {
     private String ffilter=DEFAULT_FFILTER;
 	
 	
+    private String defaultField=null;
 
 
     // whether drilldown (false) or sideway (true)
@@ -175,6 +176,7 @@ public class SearchOptions implements RequestOptions {
 		     	ofBoolean("sideway", a->setSideway(a), ()->isSideway(),true),
 		     	ofBoolean("wait", a->setWait(a), ()->isWait(),false),
 		     	ofSingleString("ffilter", a->ffilter=a, ()->ffilter),
+		     	ofSingleString("defaultField", a->defaultField=a, ()->defaultField),
 		     	ofSingleString("filter", a->filter=a, ()->filter),
 		     	ofSingleString("kind", a->{
 		     		try{
@@ -410,6 +412,7 @@ public class SearchOptions implements RequestOptions {
         private boolean includeBreakdown=true;
         private boolean promoteSpecialMatches =true;
 		
+        private String defaultField;
 		private String filter;
 		
 		private List<String> facets = new ArrayList<>();
@@ -447,6 +450,7 @@ public class SearchOptions implements RequestOptions {
 			includeFacets(so.getIncludeFacets());
 			includeBreakdown(so.getIncludeBreakdown());
 			promoteSpecialMatches(so.getPromoteSpecialMatches());
+			defaultField(so.defaultField);
 			return this;
 		}
 
@@ -484,6 +488,13 @@ public class SearchOptions implements RequestOptions {
             this.ffilter = ffilter;
             return this;
         }
+		
+		public Builder defaultField(String defaultField) {
+            this.defaultField = defaultField;
+            return this;
+        }
+        
+		
 
 		public Builder sideway(boolean sideway) {
 			this.sideway = sideway;
@@ -760,6 +771,10 @@ public class SearchOptions implements RequestOptions {
 	public boolean getPromoteSpecialMatches()  {
 	    return this.promoteSpecialMatches;
 	}
+	
+    public String getDefaultField() {
+        return this.defaultField;
+    }
 	 
 	private static FacetLongRange asDateFacet(String fname) {
 	    return asDateFacet(fname, getDefaultDateOrderMap());
@@ -844,5 +859,9 @@ public class SearchOptions implements RequestOptions {
         // Older than 2 Years
         map.put("Older than 2 years", now -> now.minusYears(6000));
         return map;
+    }
+
+    public void setDefaultField(String defaultField) {
+        this.defaultField=defaultField;
     }
 }

--- a/gsrs-spring-legacy-indexer/src/main/java/ix/core/search/text/TextIndexer.java
+++ b/gsrs-spring-legacy-indexer/src/main/java/ix/core/search/text/TextIndexer.java
@@ -2602,7 +2602,8 @@ public class TextIndexer implements Closeable, ProcessListener {
     }
     
     private boolean shouldIndexAsIdentifier(EntityInfo ei, String field) {
-
+        // Identifiers are fields considered worth matching exactly, as opposed to a general text field.
+        // Allows for searches to have an easy way to search identifier-level things (e.g. names, codes, uuids, inchis)
         Set<String> ikeys = ei.getSpecialFields();
         if (ikeys != null) {
 


### PR DESCRIPTION
This change breaks the "catch all" indexing fields into 2 fields:

text (the existing full-text index field)
identifiers (a new index field which only indexes selected fields considering worth matching _exactly_)

Doing this change allows for searches to have an easy way to search identifier-level things (names, codes, uuids, inchis) without including the whole world. API users can specify that they want the default field to be "identifiers" rather than "text".