### PR TITLE
allow = to be considered a split character

### DIFF
--- a/gsrs-spring-legacy-indexer/src/main/java/ix/core/search/text/TextIndexer.java
+++ b/gsrs-spring-legacy-indexer/src/main/java/ix/core/search/text/TextIndexer.java
@@ -1346,8 +1346,12 @@ public class TextIndexer implements Closeable, ProcessListener {
                 .compile("(\\b(?!" + ROOT + "|" + ENTITY_PREFIX +")[^ :]*_[^ :]*[:])");
         
       
+        //The version and mechanisms we use for lucene have difficulty with quotes around
+        //a single term, since that isn't considered a valid phrase query. This is part of a pre-process
+        //step to turn quoted "words" into unquoted words. This isn't a perfect solution and should
+        //be replaced with something more robust.
         private static final Pattern QUOTES_AROUND_WORD_REMOVER = Pattern
-                .compile("\"([^\" .-]*)\"");
+                .compile("\"([^\" .-=]*)\"");
 
         public IxQueryParser(String def) {
             super(def, createIndexAnalyzer());


### PR DESCRIPTION
This is a very minor change. Currently if you search for something like:
```
"CCC=CCCC"
```
in a _text_ search, unfielded, the backend will actually consider it a "word" and will remove the quotes. Making it equivalent to:
```
CCC CCCC
```
Which is currently equivalent to:
```
text:CCC OR text:CCCC
```
Which will be surprising for most people. This change is to make "=" considered a split character like space, dash, etc.