### PR TITLE
WIP: change text replacement value (xspacex xcolonx) to avoid inadvertent matches 

### DIFF
--- a/gsrs-spring-legacy-indexer/src/main/java/ix/core/search/text/ColonIndexedTextEncoder.java
+++ b/gsrs-spring-legacy-indexer/src/main/java/ix/core/search/text/ColonIndexedTextEncoder.java
@@ -9,7 +9,7 @@ import java.util.stream.Collectors;
 @Data
 public class ColonIndexedTextEncoder implements IndexedTextEncoder{
 
-    private static final String COLON_WORD = "XCOLONX";
+    private static final String COLON_WORD = "_XCLNX_";
 
     public ColonIndexedTextEncoder() {}
 
@@ -28,7 +28,7 @@ public class ColonIndexedTextEncoder implements IndexedTextEncoder{
         is needed. This is how a search having a colon should be encoded.
         Example:
         \"root_names_name:"AZT : ABC" AND root_names_name:"AZT : DEF"\"
-        ==> \"root_names_name:"AZT XCOLONX ABC" AND root_names_name:"AZT XCOLONX DEF"\"
+        ==> \"root_names_name:"AZT _XCLNX_ ABC" AND root_names_name:"AZT _XCLNX_ DEF"\"
         */
         if(qtest.contains("\"") && qtest.contains(":")){
             // We want to conserve the escaped quotes that might be in the full search term.

--- a/gsrs-spring-legacy-indexer/src/main/java/ix/core/search/text/TextIndexer.java
+++ b/gsrs-spring-legacy-indexer/src/main/java/ix/core/search/text/TextIndexer.java
@@ -129,7 +129,7 @@ public class TextIndexer implements Closeable, ProcessListener {
 	public static final String GIVEN_START_WORD = "^";
 	static final String ROOT = "root";
 	static final String ENTITY_PREFIX = "entity";	
-	private static final String SPACE_WORD = "XSPACEX";	
+	private static final String SPACE_WORD = "_XSPCX_";
 
     private static final Pattern COMPLEX_QUERY_REGEX = Pattern.compile("_.*:");
 

--- a/gsrs-spring-legacy-indexer/src/test/java/ix/core/search/QueryParseTest.java
+++ b/gsrs-spring-legacy-indexer/src/test/java/ix/core/search/QueryParseTest.java
@@ -139,7 +139,7 @@ public class QueryParseTest {
     @Test
     public void replaceSpaceButNotEscapedQuoteInReplaceStringInComplexPhraseQuery() {
 
-        assertEquals("\"*testwith\\\"escapedquoteXSPACEXworks\"",
+        assertEquals("\"*testwith\\\"escapedquote_XSPCX_works\"",
                 TextIndexer.preProcessQueryText("\"*testwith\\\"escapedquote works\""));
     }
     @Test
@@ -149,44 +149,44 @@ public class QueryParseTest {
     	assertEquals("*OAT-2*", TextIndexer.preProcessQueryText("*OAT-2*"));
     	assertEquals("OAT-2", TextIndexer.preProcessQueryText("OAT-2"));
     	
-    	assertEquals("\"*OATXSPACEX2*\"", TextIndexer.preProcessQueryText("\"*OAT.2*\""));
-    	assertEquals("\"*OATXSPACEX2*\"", TextIndexer.preProcessQueryText("\"*OAT&2*\""));    	
-    	assertEquals("\"*OATXSPACEX2\"", TextIndexer.preProcessQueryText("\"*OAT-2\""));
-    	assertEquals("\"OATXSPACEX2*\"", TextIndexer.preProcessQueryText("\"OAT 2*\""));
+    	assertEquals("\"*OAT_XSPCX_2*\"", TextIndexer.preProcessQueryText("\"*OAT.2*\""));
+    	assertEquals("\"*OAT_XSPCX_2*\"", TextIndexer.preProcessQueryText("\"*OAT&2*\""));    	
+    	assertEquals("\"*OAT_XSPCX_2\"", TextIndexer.preProcessQueryText("\"*OAT-2\""));
+    	assertEquals("\"OAT_XSPCX_2*\"", TextIndexer.preProcessQueryText("\"OAT 2*\""));
     	    	
-    	assertEquals("root_names_name:\"aspirin sodium\" AND \"*TEST123XSPACEX456*\"", 
+    	assertEquals("root_names_name:\"aspirin sodium\" AND \"*TEST123_XSPCX_456*\"", 
     			TextIndexer.preProcessQueryText("root_names_name:\"aspirin sodium\" AND \"*TEST123 456*\""));
     	
-    	assertEquals("root_names_name:\"*aspirinXSPACEXsodium*\" AND \"*TEST123XSPACEX456*\"", 
+    	assertEquals("root_names_name:\"*aspirin_XSPCX_sodium*\" AND \"*TEST123_XSPCX_456*\"", 
     			TextIndexer.preProcessQueryText("root_names_name:\"*aspirin sodium*\" AND \"*TEST123 456*\""));
     	
-    	assertEquals("\"*OATXSPACEX2XSPACEXBETAXSPACEX*\"", TextIndexer.preProcessQueryText("\"*OAT-2β*\""));
-    	assertEquals("\"*OATXSPACEXXSPACEXXSPACEX2*\"", TextIndexer.preProcessQueryText("\"*OAT-.&2*\""));
+    	assertEquals("\"*OAT_XSPCX_2_XSPCX_BETA_XSPCX_*\"", TextIndexer.preProcessQueryText("\"*OAT-2β*\""));
+    	assertEquals("\"*OAT_XSPCX__XSPCX__XSPCX_2*\"", TextIndexer.preProcessQueryText("\"*OAT-.&2*\""));
     	
-    	assertEquals("root_names_name:\"abcXSPACEXXSPACEXBETAXSPACEXdef*\"", 
+    	assertEquals("root_names_name:\"abc_XSPCX__XSPCX_BETA_XSPCX_def*\"", 
     			TextIndexer.preProcessQueryText("root_names_name:\"abc-βdef*\""));
     	
-    	assertEquals("\"*TEST123XSPACEX456*\"", TextIndexer.preProcessQueryText("\"*TEST123 456*\""));
+    	assertEquals("\"*TEST123_XSPCX_456*\"", TextIndexer.preProcessQueryText("\"*TEST123 456*\""));
     	
-    	assertEquals("\"*TEST123XSPACEX456\" and root_lastEdited:[-10E50 TO 10E50]", 
+    	assertEquals("\"*TEST123_XSPCX_456\" and root_lastEdited:[-10E50 TO 10E50]", 
     			TextIndexer.preProcessQueryText("\"*TEST123 456\" and root_lastEdited:[-10E50 TO 10E50]"));
     	
-    	assertEquals("\"*TEST123XSPACEX456*\" AND root_names_name:\"aspirin sodium\"", 
+    	assertEquals("\"*TEST123_XSPCX_456*\" AND root_names_name:\"aspirin sodium\"", 
     			TextIndexer.preProcessQueryText("\"*TEST123 456*\" AND root_names_name:\"aspirin sodium\""));
     	
     	assertEquals("root_names_name:\"OCT*\"", TextIndexer.preProcessQueryText("root_names_name:\"OCT*\""));
     	assertEquals("root_names_name:\"abc*\" AND def*", TextIndexer.preProcessQueryText("root_names_name:\"abc*\" AND def*"));
     	
-    	assertEquals("root_names_name:\"OATXSPACEX2*\" AND abc-def*", 
+    	assertEquals("root_names_name:\"OAT_XSPCX_2*\" AND abc-def*", 
     			TextIndexer.preProcessQueryText("root_names_name:\"OAT-2*\" AND abc-def*"));
     	
-    	assertEquals("root_names_name:\"*OCTXSPACEX1*\"", TextIndexer.preProcessQueryText("root_names_name:\"*OCT-1*\""));
-    	assertEquals("root_names_name:  \"*OCTXSPACEX123*\"", TextIndexer.preProcessQueryText("root_names_name:  \"*OCT&123*\""));
+    	assertEquals("root_names_name:\"*OCT_XSPCX_1*\"", TextIndexer.preProcessQueryText("root_names_name:\"*OCT-1*\""));
+    	assertEquals("root_names_name:  \"*OCT_XSPCX_123*\"", TextIndexer.preProcessQueryText("root_names_name:  \"*OCT&123*\""));
     	
-    	assertEquals("root_names_name:\"*OCTXSPACEX1*\" AND   root_codes_code:\"*OCTXSPACEX2*\" OR root_approvalID:\"*OCTXSPACEX3*\"", 
+    	assertEquals("root_names_name:\"*OCT_XSPCX_1*\" AND   root_codes_code:\"*OCT_XSPCX_2*\" OR root_approvalID:\"*OCT_XSPCX_3*\"", 
     			TextIndexer.preProcessQueryText("root_names_name:\"*OCT-1*\" AND   root_codes_code:\"*OCT-2*\" OR root_approvalID:\"*OCT-3*\""));    	
     	
-    	assertEquals("(root_names_name:\"*OCTXSPACEX2*\" AND root_codes_code:\"*OCTXSPACEX2*\") OR (root_approvalID:\"*OCTXSPACEX3*\" AND root_references_citation:\"*OCTXSPACEX4*\")",
+    	assertEquals("(root_names_name:\"*OCT_XSPCX_2*\" AND root_codes_code:\"*OCT_XSPCX_2*\") OR (root_approvalID:\"*OCT_XSPCX_3*\" AND root_references_citation:\"*OCT_XSPCX_4*\")",
     			TextIndexer.preProcessQueryText("(root_names_name:\"*OCT 2*\" AND root_codes_code:\"*OCT 2*\") OR (root_approvalID:\"*OCT 3*\" AND root_references_citation:\"*OCT-4*\")"));
     	
     	

--- a/gsrs-spring-legacy-indexer/src/test/java/ix/core/search/text/ColonIndexedTextEncoderTest.java
+++ b/gsrs-spring-legacy-indexer/src/test/java/ix/core/search/text/ColonIndexedTextEncoderTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 
 
 public class ColonIndexedTextEncoderTest {
-    private static final String TEST_COLON_WORD = "XCOLONX";
+    private static final String TEST_COLON_WORD = "_XCLNX_";
 
     @Test
     public void basicEncoderTest() throws Exception {


### PR DESCRIPTION
The text replacement values (SPACE_WORD, COLON_WORD)  were causing searches like this:

 "glax*" 
 
 to inadvertently match something like this:
 
  "gla abc"
  
 because of the replacement glaXSPACEXabc. Similar for XCOLONX. 

So, I changed values _WORD values to _XSPCX_ and _XCLNX_

I have tried searches with rep18 and they seem to work. 

My only worries were:

1) That lucene might split on _ underscore. Tyler is 90% sure it doesn't.
2) underscore _ could lead to some _xyz: patterns that trigger the backend to think we have a complex search (such as root_names_name:abc.  But, it seems that the checks for this pattern target the query term rather than the query term with replacements.   For example here: 

```
                 if (!tqq.contains("*") && !COMPLEX_QUERY_REGEX.matcher(tqq).find() && !tqq.contains(" AND ") && !tqq.contains(" OR ")) {

```