### PR TITLE
Fix keys for structure highlighting

### DIFF
--- a/gsrs-spring-legacy-cache/src/main/java/ix/core/cache/IxCache.java
+++ b/gsrs-spring-legacy-cache/src/main/java/ix/core/cache/IxCache.java
@@ -139,12 +139,12 @@ public class IxCache implements GsrsCache {
 	
 	@Override
     public void addToMatchingContext(String contextID, Key key, String prop, Object value){
-        Map<String,Object> additionalProps = getMatchingContextByContextID(contextID, key);
+        Map<String,Object> additionalProps = getMatchingContextByContextID(contextID, key.toRootKey());
         if(additionalProps==null){
             additionalProps=new HashMap<String,Object>();
         }
         additionalProps.put(prop, value);
-        setMatchingContext(contextID,key, additionalProps);
+        setMatchingContext(contextID,key.toRootKey(), additionalProps);
     }
 	
 	@Override

--- a/gsrs-spring-legacy-indexer/src/main/java/ix/core/search/bulk/BulkSearchResultProcessor.java
+++ b/gsrs-spring-legacy-indexer/src/main/java/ix/core/search/bulk/BulkSearchResultProcessor.java
@@ -35,7 +35,7 @@ public class BulkSearchResultProcessor<T> extends SearchResultProcessor<BulkSear
 
 	private void addBulkResultToSubstanceMatchContext(BulkSearchResult r) {		
 		Map<String, Object> map = new HashMap<>();
-		map.put("queries", matches.get(r.getKey()));
-		ixCache.setMatchingContext(this.getContext().getId(), r.getKey(), map);
+		map.put("queries", matches.get(r.getKey().toRootKey()));
+		ixCache.setMatchingContext(this.getContext().getId(), r.getKey().toRootKey(), map);
 	}
 }


### PR DESCRIPTION
This fixes keys to use rootKeys for context matching. Used for similarity, bulk, sequence and structure highlights.