### PR TITLE
force creation of the foreign key indexes

### DIFF
--- a/gsrs-controlled-vocabulary/src/main/java/ix/ginas/models/v1/VocabularyTerm.java
+++ b/gsrs-controlled-vocabulary/src/main/java/ix/ginas/models/v1/VocabularyTerm.java
@@ -20,7 +20,7 @@ import javax.persistence.*;
  */
 
 @Entity
-@Table(name="ix_ginas_vocabulary_term")
+@Table(name="ix_ginas_vocabulary_term", indexes = {@Index(name = "vocabulary_term_owner_index", columnList = "owner_id")})
 @Inheritance
 @DiscriminatorValue("VOCAB")
 @SingleParent


### PR DESCRIPTION
This PR will create a foreign key indexes on PostgreSQL (Oracle) databases. It fixes the ncats/gsrs-spring-module-substances#130 Issue.