### PR TITLE
WIP: Index partial

### DIFF
--- a/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/controller/AbstractLegacyTextSearchGsrsEntityController.java
+++ b/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/controller/AbstractLegacyTextSearchGsrsEntityController.java
@@ -4,9 +4,11 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
@@ -32,8 +34,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -54,20 +54,20 @@ import gsrs.services.TextService;
 import gsrs.springUtils.StaticContextAccessor;
 import ix.core.EntityFetcher;
 import ix.core.models.ETag;
-import ix.core.models.BaseModel;
 import ix.core.search.GsrsLegacySearchController;
 import ix.core.search.SearchOptions;
 import ix.core.search.SearchRequest;
 import ix.core.search.SearchResult;
 import ix.core.search.SearchResultContext;
-import ix.core.search.bulk.UserSavedListService;
-import ix.core.search.bulk.UserSavedListService.Operation;
 import ix.core.search.bulk.BulkSearchService;
 import ix.core.search.bulk.BulkSearchService.BulkQuerySummary;
 import ix.core.search.bulk.ResultListRecord;
 import ix.core.search.bulk.ResultListRecordGenerator;
+import ix.core.search.bulk.UserSavedListService;
+import ix.core.search.bulk.UserSavedListService.Operation;
 import ix.core.search.text.FacetMeta;
 import ix.core.search.text.TextIndexer;
+import ix.core.search.text.TextIndexerFactory;
 import ix.core.util.EntityUtils.EntityWrapper;
 import ix.core.util.EntityUtils.Key;
 import ix.utils.CallableUtil;
@@ -1191,7 +1191,14 @@ GET     /suggest       ix.core.controllers.search.SearchFactory.suggest(q: Strin
     private void reIndexWithKeys(UserListStatus status, List<String> keyIds) { 
     	
     	int total = status.getTotal();
-    	for(String id: keyIds) {    		
+    	
+    	//TODO: should use indexing event instead
+    	TextIndexerFactory tif = StaticContextAccessor.getBean(TextIndexerFactory.class);
+    	Set<String> userFieldSet = new HashSet<>();
+    	userFieldSet.add("User List");
+    	
+    	
+    	keyIds.parallelStream().forEach(id->{
     		try {
 
     			Optional<String> entityID = getEntityService().getEntityIdOnlyBySomeIdentifier(id).map(ii->ii.toString());
@@ -1199,8 +1206,10 @@ GET     /suggest       ix.core.controllers.search.SearchFactory.suggest(q: Strin
     			if(entityID.isPresent()) {    			
     				Class eclass = getEntityService().getEntityClass();
                     Key k = Key.ofStringId(eclass, entityID.get());
-                    Object o = EntityFetcher.of(k).call();                    
-    				getlegacyGsrsSearchService().reindex(o, true);    				
+                    Object o = EntityFetcher.of(k).call();      
+                    
+                    tif.getDefaultInstance().updateFields(EntityWrapper.of(o), userFieldSet);
+    				//getlegacyGsrsSearchService().reindex(o, true);    				
     			
     			}else {
     				log.warn("Cannot get the object during reindexing id: " + id);
@@ -1219,7 +1228,8 @@ GET     /suggest       ix.core.controllers.search.SearchFactory.suggest(q: Strin
     			log.warn("trouble reindexing id: " + id, e);
 			
     		}   
-    	}
+    	});
+    	
 		
     	
     }

--- a/gsrs-spring-legacy-indexer/src/main/java/ix/core/search/text/CombinedIndexValueMaker.java
+++ b/gsrs-spring-legacy-indexer/src/main/java/ix/core/search/text/CombinedIndexValueMaker.java
@@ -1,7 +1,11 @@
 package ix.core.search.text;
 
 import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import org.apache.commons.collections4.SetUtils;
 
 public class CombinedIndexValueMaker<T> implements IndexValueMaker<T> {
     private final List<IndexValueMaker<? super T>> list;
@@ -14,6 +18,16 @@ public class CombinedIndexValueMaker<T> implements IndexValueMaker<T> {
     @Override
     public Class<T> getIndexedEntityClass() {
         return clazz;
+    }
+    
+    @Override
+    public IndexValueMaker<T> restrictedForm(Set<String> fields){
+    	List<IndexValueMaker<T>> filteredList=list.stream()
+    	.filter(ivm->ivm.getFieldNames().stream().anyMatch(fn->fields.contains(fn)))
+    	.map(ivm->(IndexValueMaker<T>)ivm.restrictedForm(fields))
+    	.collect(Collectors.toList());
+    	
+    	return new CombinedIndexValueMaker(clazz,filteredList);
     }
 
     @Override

--- a/gsrs-spring-legacy-indexer/src/main/java/ix/core/search/text/CombinedIndexValueMaker.java
+++ b/gsrs-spring-legacy-indexer/src/main/java/ix/core/search/text/CombinedIndexValueMaker.java
@@ -21,6 +21,12 @@ public class CombinedIndexValueMaker<T> implements IndexValueMaker<T> {
     }
     
     @Override
+    public Set<String> getFieldNames(){
+    	return list.stream().flatMap(ss->ss.getFieldNames().stream()).collect(Collectors.toSet());
+    }
+    
+    
+    @Override
     public IndexValueMaker<T> restrictedForm(Set<String> fields){
     	List<IndexValueMaker<T>> filteredList=list.stream()
     	.filter(ivm->ivm.getFieldNames().stream().anyMatch(fn->fields.contains(fn)))

--- a/gsrs-spring-legacy-indexer/src/main/java/ix/core/search/text/IndexValueMaker.java
+++ b/gsrs-spring-legacy-indexer/src/main/java/ix/core/search/text/IndexValueMaker.java
@@ -1,9 +1,8 @@
 package ix.core.search.text;
 
-import lombok.extern.slf4j.Slf4j;
-
-
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.function.Consumer;
 
 /**
@@ -38,6 +37,14 @@ public interface IndexValueMaker<T> {
 	 */
 	void createIndexableValues(T t, Consumer<IndexableValue> consumer);
 	
+	
+	default Set<String> getFieldNames(){
+		return new HashSet<>();
+	}
+	
+	default IndexValueMaker<T> restrictedForm(Set<String> fields){
+		return this;
+	}
 	
 	/**
 	 * Combine 2 IndexValueMakers together, so that

--- a/gsrs-spring-legacy-indexer/src/main/java/ix/core/search/text/TextIndexer.java
+++ b/gsrs-spring-legacy-indexer/src/main/java/ix/core/search/text/TextIndexer.java
@@ -28,6 +28,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -2947,6 +2948,142 @@ public class TextIndexer implements Closeable, ProcessListener {
         }
 
     }
+	
+	public void updateFields(EntityWrapper ew, Set<String> fields) throws IOException{
+        log.trace("starting in update, key: {}", ew.getKey());
+	    Lock l = stripedLock.get(ew.getKey());
+	    l.lock();
+	    
+	    try{
+	    	//as it was before
+	    	IndexRecord ix =getIndexRecord(ew.getKey());
+	    	
+	    	
+	    	ix.facets=ix.facets.stream().filter(iff->!fields.contains(iff.getFacetName())).collect(Collectors.toList());
+	    	ix.fields=ix.fields.stream().filter(iff->!fields.contains(iff.getFieldName())).collect(Collectors.toList());
+	    	ix.suggest=ix.suggest.stream().filter(iff->!fields.contains(iff.getSuggestName())).collect(Collectors.toList());
+	    	
+	    	
+	    		    	
+            remove(ew);
+            add(ew,fields,ix);
+        } catch (Exception e) {
+			e.printStackTrace();
+			//fallback to normal indexing
+			update(ew);
+		}finally{
+	        l.unlock();
+        }
+
+    }
+	
+    
+    /**
+	 * recursively index any object annotated with Entity, only use selected IVMs and store the delta
+	 * 
+	 */
+	private void add(EntityWrapper ew, Set<String> filters,IndexRecord ix) throws IOException {
+		ew.toInternalJson();
+        Document doc = new Document();
+        Document docExact = new Document();
+        if(textIndexerConfig.isShouldLog()){
+            LogUtil.debug(()->{
+                String beanId;
+                if(ew.hasIdField()){
+                    beanId = ew.getKey().toString();
+                }else{
+                    beanId = ew.toString();
+                }
+                return "[LOG_INDEX] =======================\nINDEXING BEAN "+ beanId;
+            });
+
+        }
+        Key kk = ew.getKey().toRootKey();
+        
+        
+        
+        //make a version that only does the fields in question
+		IndexValueMaker<Object> valueMaker= indexValueMakerFactory.createIndexValueMakerFor(ew)
+				                                                  .restrictedForm(filters);
+		valueMaker.createIndexableValues(ew.getValue(), iv->{
+			this.instrumentIndexableValue(ix, iv, ie->{
+				return filters.contains(ie.getIndexFieldName());
+			});
+		});
+        
+		// Now that the record is built,
+		// we need to process it
+		IndexRecordProcessor irp = new IndexRecordProcessor(doc, ix, kk.getEntityInfo(),  this);
+		irp.process();
+		
+//		fieldCollector.accept(new StringField(FIELD_KIND, ew.getKind(), YES));
+//		fieldCollector.accept(new StringField(ANALYZER_MARKER_FIELD, "false", YES));
+		
+		irp.numericFieldList.forEach((n,v)->{
+			  if(v.size()==1) {
+			      doc.add(v.get(0));
+			  }else {
+			      v.forEach(iff->{
+			          double d =iff.numericValue().doubleValue();
+			          doc.add(new DoubleField(n, d, NO));
+			      });
+			  }
+			});
+		
+
+		// now index
+		addDoc(doc);
+		
+
+		Tuple<String,String> luceneKey = kk.asLuceneIdTuple();
+		
+		//ID
+		docExact.add(new StringField(FULL_DOC_PREFIX + luceneKey.k() , luceneKey.v(),YES));
+		
+		docExact.add(new StringField(FIELD_KIND, FULL_DOC_PREFIX + kk.getKind(),YES));
+		docExact.add(new SortedDocValuesField(FIELD_KIND,new BytesRef(FULL_DOC_PREFIX + kk.getKind())));
+		docExact.add(new StoredField(FIELD_KIND, new BytesRef(FULL_DOC_PREFIX + kk.getKind())));
+		
+		docExact.add(new StoredField("FULL_INDEX", new BytesRef(EntityWrapper.of(ix).toInternalJson())));
+		docExact.add(new StringField(ANALYZER_MARKER_FIELD, "false",YES));
+		
+		indexerService.addDocument(docExact);
+		
+		if(ix.isDeepAnalyzed()){
+			
+			if(!kk.getIdString().equals("")){  //probably not needed
+				StringField toAnalyze=new StringField(FIELD_KIND, ANALYZER_VAL_PREFIX + kk.getKind(),YES);
+				SortedDocValuesField toAnalyze2= new SortedDocValuesField(FIELD_KIND,new BytesRef(ANALYZER_VAL_PREFIX + kk.getKind()));
+				StoredField toAnalyze3= new StoredField(FIELD_KIND, new BytesRef(ANALYZER_VAL_PREFIX + kk.getKind()));
+				StringField analyzeMarker=new StringField(ANALYZER_MARKER_FIELD, "true",YES);
+
+
+				StringField docParent=new StringField(ANALYZER_VAL_PREFIX+luceneKey.k(),luceneKey.v(),YES);
+				FacetField docParentFacet =new FacetField(ANALYZER_VAL_PREFIX+luceneKey.k(),luceneKey.v());
+				//This is a test of a terrible idea, which just. might. work.
+				irp.fullText.forEach((name,group)->{
+						try{
+                            Document fielddoc = new Document();
+							fielddoc.add(toAnalyze);
+							fielddoc.add(toAnalyze2);
+							fielddoc.add(toAnalyze3);
+							fielddoc.add(analyzeMarker);
+							fielddoc.add(docParent);
+							fielddoc.add(docParentFacet);
+							fielddoc.add(new FacetField(ANALYZER_FIELD,name));
+							for(String f:group){
+									fielddoc.add(new TextField(FULL_TEXT_FIELD, f, NO));
+							}
+							addDoc(fielddoc);
+						}catch(Exception e){
+							log.error("Analyzing index failed", e);
+						}
+					});
+			}
+		}
+
+	}
+    
 		
     public void add(EntityWrapper ew) throws IOException {
         //Don't index if any of the following:
@@ -3007,6 +3144,8 @@ public class TextIndexer implements Closeable, ProcessListener {
     
     static interface IndexedElement{
     	
+    	@JsonIgnore
+    	public String getIndexFieldName();
     }
 
     static enum IndexedFieldType{
@@ -3041,6 +3180,11 @@ public class TextIndexer implements Closeable, ProcessListener {
     	private boolean stored;
     	private boolean sortable;
     	private boolean exactText;
+    	
+    	@JsonIgnore
+    	public String getIndexFieldName() {
+    		return this.getFieldName();
+    	}
     	
     	@JsonIgnore
     	public boolean isTextual() {
@@ -3078,6 +3222,11 @@ public class TextIndexer implements Closeable, ProcessListener {
     	private String suggestName;
     	private String suggestValue;
     	private int suggestWeight;
+    	
+    	@JsonIgnore
+    	public String getIndexFieldName() {
+    		return this.getSuggestName();
+    	}
 	}
 
     
@@ -3096,6 +3245,10 @@ public class TextIndexer implements Closeable, ProcessListener {
     	private String format;
     	private boolean hierarchical;
 
+    	@JsonIgnore
+    	public String getIndexFieldName() {
+    		return this.getFacetName();
+    	}
     	
     	@JsonIgnore
     	public String getFirstValue() {
@@ -3288,9 +3441,7 @@ public class TextIndexer implements Closeable, ProcessListener {
     			}
     	 }
     }
-    
-    
-    
+
 	/**
 	 * recursively index any object annotated with Entity
 	 */
@@ -3977,37 +4128,55 @@ public class TextIndexer implements Closeable, ProcessListener {
 
 	//make the fields for the dynamic facets
 
-	public void createDynamicField(IndexRecord record, IndexableValue iv) {
+	public void createDynamicField(IndexRecord record, IndexableValue iv, Predicate<IndexedElement> allowAdding) {
 		facetsConfig.setMultiValued(iv.name(), true);
 		facetsConfig.setRequireDimCount(iv.name(), true);
 		String val= iv.value().toString();
 		
-		record.facets.add(IndexedFacet.builder().type(IndexedFieldType.STRING).facetName(iv.name()).facetValue(val).build());
+		IndexedFacet ifac=IndexedFacet.builder().type(IndexedFieldType.STRING).facetName(iv.name()).facetValue(val).build();
+		if(allowAdding.test(ifac)) {
+			record.facets.add(ifac);
+		}
+		
+		
 		
 		//for all fields we need to add 2 versions that are exact/continuous
-		record.fields.add(IndexedField.builder()
+		IndexedField iff =IndexedField.builder()
 				.type(IndexedFieldType.TEXT)
 				.fieldName(iv.path())
 				.fieldValue(val)
 				.exactText(true)
 				.sortable(iv.sortable())
-				.build());
+				.build();
+		
+		if(allowAdding.test(iff)) {
+			record.fields.add(iff);
+		}
+		
+		
 //		record.fields.add(IndexedField.builder().fieldName(iv.path()).fieldValue(toExactMatchString(val)).build());
 //		record.fields.add(IndexedField.builder().fieldName(iv.path()).fieldValue(toExactMatchStringContinuous(val)).build());
 		
 		if(iv.suggest()){
-			record.suggest.add(IndexedSuggestField.builder()
+			IndexedSuggestField isf=IndexedSuggestField.builder()
 					.suggestName(iv.name())
 					.suggestValue(iv.value().toString())
 					.suggestWeight(iv.suggestWeight())
-					.build());
+					.build();
+			if(allowAdding.test(isf)) {
+				record.suggest.add(isf);
+			}
 		}
 
 	}
 
 	//make the fields for the primitive fields
-
 	public void instrumentIndexableValue(IndexRecord record, IndexableValue indexableValue) {
+		instrumentIndexableValue(record, indexableValue, (ie)->true);
+		
+	}
+	
+	public void instrumentIndexableValue(IndexRecord record, IndexableValue indexableValue, Predicate<IndexedElement> allowAdding) {
 
 
 		//TODO: may need to change
@@ -4020,32 +4189,44 @@ public class TextIndexer implements Closeable, ProcessListener {
 				if(ifx instanceof TextField) type = IndexedFieldType.TEXT;
 				if(ifx instanceof StringField) type = IndexedFieldType.STRING;
 				
-				record.fields.add(IndexedField.builder()
-						.fieldName(ifx.name())
-						.fieldValue(ifx.stringValue())
-						.stored(ifx.fieldType().stored())
-						.type(type)
-						.build());
+				IndexedField iff= IndexedField.builder()
+												.fieldName(ifx.name())
+												.fieldValue(ifx.stringValue())
+												.stored(ifx.fieldType().stored())
+												.type(type)
+												.build();
+				
+				if(allowAdding.test(iff)) {
+					record.fields.add(iff);
+				}
 			}else if(ifx instanceof FacetField) {
 				FacetField ff = (FacetField)ifx;
 				String key=ff.dim;
 				String val=ff.path[0];
 				
+				IndexedFacet iff=IndexedFacet.builder()
+				.facetName(key)
+				.facetValue(val)
+				.type(IndexedFieldType.STRING)
+				.build();
 				
-				record.facets.add(IndexedFacet.builder()
-						.facetName(key)
-						.facetValue(val)
-						.type(IndexedFieldType.STRING)
-						.build());
+				if(allowAdding.test(iff)) {
+					record.facets.add(iff);
+				}
 			}else if(ifx instanceof LongField) {
 				LongField lf = (LongField)ifx;
 				
-				record.fields.add(IndexedField.builder()
+				IndexedField iff = IndexedField.builder()
 						.fieldName(lf.name())
 						.fieldValue(lf.numericValue().longValue()+"")
 						.stored(lf.fieldType().stored())
 						.type(IndexedFieldType.INTEGER)
-						.build());
+						.build();
+				
+				
+				if(allowAdding.test(iff)) {
+					record.fields.add(iff);
+				}
 			}else {
 				
 				throw new IllegalStateException("Does not support direct lucene fields of type:" + ifx.getClass().getName());
@@ -4054,7 +4235,7 @@ public class TextIndexer implements Closeable, ProcessListener {
 		}
 
 		if(indexableValue.isDynamicFacet()){
-			createDynamicField(record,indexableValue);
+			createDynamicField(record,indexableValue,allowAdding);
 			//TODO
 //			if(indexableValue.sortable()){
 //			    String f=SORT_PREFIX + indexableValue.name();
@@ -4094,19 +4275,26 @@ public class TextIndexer implements Closeable, ProcessListener {
 			boolean addedFacet = false;
 			if(nvalue instanceof Long  || nvalue instanceof Integer || (indexableValue.ranges()!=null && indexableValue.ranges().length>0)){
 			    Long lval =  dval.longValue();
-			    record.fields.add(IndexedField.builder()
-			    		.type(IndexedFieldType.INTEGER)
-						.fieldName(full)
-						.fieldValue(lval+"")
-						.build());
+			    IndexedField iff=IndexedField.builder()
+								    		.type(IndexedFieldType.INTEGER)
+											.fieldName(full)
+											.fieldValue(lval+"")
+											.build();
+			    if(allowAdding.test(iff)) {
+			    	record.fields.add(iff);
+			    }
 //			    fields.accept(new NumericDocValuesField(full, lval));
 			    asText = indexableValue.facet();
 			    if (!asText && !name.equals(full)) {
-			    	record.fields.add(IndexedField.builder()
+			    	IndexedField iff2 = IndexedField.builder()
 				    		.type(IndexedFieldType.INTEGER)
 							.fieldName(name)
 							.fieldValue(lval+"")
-							.build());
+							.build();
+			    	if(allowAdding.test(iff2)) {
+			    		record.fields.add(iff2);
+			    	}
+			    	
 //			        fields.accept(new NumericDocValuesField(name, lval));
 			    }
 			    if(indexableValue.facet()){
@@ -4114,12 +4302,16 @@ public class TextIndexer implements Closeable, ProcessListener {
 			    	if(buck!=null && buck.length>0) {
 				    	double[] buck2 = Arrays.stream(buck).mapToDouble(i->(double)i).toArray();
 				    	
-				    	record.facets.add(IndexedFacet.builder()
+				    	IndexedFacet ifac2=IndexedFacet.builder()
 				    			.type(IndexedFieldType.INTEGER)
 					    		.facetName(fname)
 					    		.facetValue(lval+"")
 					    		.buckets(buck2)
-								.build());
+								.build();
+				    	
+				    	if(allowAdding.test(ifac2)) {
+				    		record.facets.add(ifac2);
+				    	}
 				    	
 				        //FacetField ffl = getRangeFacet(fname, indexableValue.ranges(), lval);
 				        asText = false;
@@ -4128,38 +4320,55 @@ public class TextIndexer implements Closeable, ProcessListener {
 			    }
 			}
 
-			record.fields.add(IndexedField.builder()
-		    		.type(IndexedFieldType.DOUBLE)
-					.fieldName("D_" +full)
-					.fieldValue(dval.doubleValue()+"")
-					.build());
+			IndexedField iffD= IndexedField.builder()
+							    		.type(IndexedFieldType.DOUBLE)
+										.fieldName("D_" +full)
+										.fieldValue(dval.doubleValue()+"")
+										.build();
+			if(allowAdding.test(iffD)) {
+				record.fields.add(iffD);
+			}
 			
 			if (indexableValue.sortable()) {
 				sorterAdded = true;
-				record.fields.add(IndexedField.builder()
-						.type(IndexedFieldType.DOUBLE)
-						.fieldName(full)
-						.fieldValue(dval.doubleValue()+"")
-						.sortable(true)
-						.build());
+				
+				IndexedField iffS=IndexedField.builder()
+				.type(IndexedFieldType.DOUBLE)
+				.fieldName(full)
+				.fieldValue(dval.doubleValue()+"")
+				.sortable(true)
+				.build();
+				
+				if(allowAdding.test(iffS)) {
+					record.fields.add(iffS);
+				}
 			}
 
 			if (!name.equals(full)) {
-				record.fields.add(IndexedField.builder()
-						.type(IndexedFieldType.DOUBLE)
-						.fieldName("D_" +name)
-						.fieldValue(dval.doubleValue()+"")
-						.build());
+				IndexedField iffD2=IndexedField.builder()
+				.type(IndexedFieldType.DOUBLE)
+				.fieldName("D_" +name)
+				.fieldValue(dval.doubleValue()+"")
+				.build();
+				if(allowAdding.test(iffD2)) {
+					record.fields.add(iffD2);
+				}				
 			}
 			
 			if(indexableValue.facet() && !addedFacet){
-				record.facets.add(IndexedFacet.builder()
-		    			.type(IndexedFieldType.DOUBLE)
-			    		.facetName(fname)
-			    		.facetValue(dval.doubleValue()+"")
-			    		.buckets(indexableValue.dranges())
-			    		.format(indexableValue.format())
-						.build());
+				
+				IndexedFacet ifac2= IndexedFacet.builder()
+    			.type(IndexedFieldType.DOUBLE)
+	    		.facetName(fname)
+	    		.facetValue(dval.doubleValue()+"")
+	    		.buckets(indexableValue.dranges())
+	    		.format(indexableValue.format())
+				.build();
+				
+				if(allowAdding.test(ifac2)) {
+					record.facets.add(ifac2);
+				}
+				
 //			    FacetField ff = getRangeFacet(fname, indexableValue.dranges(), dval.doubleValue(), indexableValue.format());
 //			    if (ff != null) {
 //			        facetsConfig.setMultiValued(fname, true);
@@ -4198,25 +4407,35 @@ public class TextIndexer implements Closeable, ProcessListener {
 //					facetsConfig.setHierarchical(dim, true);
 					String val = Arrays.stream(indexableValue.splitPath(text))
 					      .collect(Collectors.joining(FACET_DELIMITER));
-					record.facets.add(IndexedFacet.builder()
-							.type(IndexedFieldType.STRING)
-							.facetName(dim)
-							.facetValue(val)
-							.hierarchical(true)
-							.build());
+					IndexedFacet ifacTax= IndexedFacet.builder()
+													.type(IndexedFieldType.STRING)
+													.facetName(dim)
+													.facetValue(val)
+													.hierarchical(true)
+													.build();
+					if(allowAdding.test(ifacTax)) {
+						record.facets.add(ifacTax);
+					}
 				} else {
                     if(indexableValue.useFullPath()){
-                        record.facets.add(IndexedFacet.builder()
+                    	IndexedFacet ifacP=IndexedFacet.builder()
     							.facetName(full)
     							.facetValue(text)
     							.type(IndexedFieldType.STRING)
-    							.build());
+    							.build();
+                    	if(allowAdding.test(ifacP)) {
+                    		 record.facets.add(ifacP);
+                    	}                       
                     }else {
-                    	record.facets.add(IndexedFacet.builder()
+                    	IndexedFacet ifacN =IndexedFacet.builder()
     							.facetName(dim)
     							.facetValue(text)
     							.type(IndexedFieldType.STRING)
-    							.build());
+    							.build();
+                    	if(allowAdding.test(ifacN)) {
+                    		record.facets.add(ifacN);	
+                    	}
+                    	
                     }
 				}
 			}
@@ -4224,17 +4443,25 @@ public class TextIndexer implements Closeable, ProcessListener {
 			if (indexableValue.suggest()) {
 				// also index the corresponding text field with the
 				// dimension name
-				record.fields.add(IndexedField.builder()
-						.fieldName(dim)
-						.fieldValue(text)
-						.type(IndexedFieldType.TEXT) // text?
-						.build());
+				IndexedField iffNonSugg = IndexedField.builder()
+				.fieldName(dim)
+				.fieldValue(text)
+				.type(IndexedFieldType.TEXT) // text?
+				.build();
+				if(allowAdding.test(iffNonSugg)) {
+					record.fields.add(iffNonSugg);
+				}
 				
-				record.suggest.add(IndexedSuggestField.builder()
+				IndexedSuggestField iffSugg =IndexedSuggestField.builder()
 						.suggestName(dim)
 						.suggestValue(text)
 						.suggestWeight(indexableValue.suggestWeight())
-						.build());
+						.build();
+				
+				if(allowAdding.test(iffSugg)) {
+					record.suggest.add(iffSugg);	
+				}
+				
 //				fields.accept(new TextField(dim, text, NO));
 //				addSuggestedField(dim, text, indexableValue.suggestWeight());
 			}
@@ -4245,26 +4472,31 @@ public class TextIndexer implements Closeable, ProcessListener {
 			if (!(value instanceof Number)) {
 				if (!full.equals(name)){
 					// Added exact match
-					record.fields.add(IndexedField.builder()
-							.fieldName(name)
-							.fieldValue(text)
-							.type(IndexedFieldType.TEXT)
-							.exactText(true)
-							.build());
+					IndexedField iffExa= IndexedField.builder()
+													.fieldName(name)
+													.fieldValue(text)
+													.type(IndexedFieldType.TEXT)
+													.exactText(true)
+													.build();
+					if(allowAdding.test(iffExa)) {
+						record.fields.add(iffExa);
+					}
 //					fields.accept(new TextField(name,exactMatchStr, NO));
 //					fields.accept(new TextField(name,exactMatchStrContinuous , NO));
 				}
 			}
 
-
+			IndexedField iffExact2 = IndexedField.builder()
+			.fieldName(full)
+			.fieldValue(text)
+			.type(IndexedFieldType.TEXT)
+			.exactText(true)
+			.sortable(indexableValue.sortable() && !sorterAdded)
+			.build();
 			
-			record.fields.add(IndexedField.builder()
-					.fieldName(full)
-					.fieldValue(text)
-					.type(IndexedFieldType.TEXT)
-					.exactText(true)
-					.sortable(indexableValue.sortable() && !sorterAdded)
-					.build());
+			if(allowAdding.test(iffExact2)) {
+				record.fields.add(iffExact2);
+			}
 			
 			// Added exact match
 //			fields.accept(new TextField(full, exactMatchStr , store));


### PR DESCRIPTION
This change allows reindexing to be done for partial fields. It does this by making the following changes:

1. The IndexValuemaker interface now allows (but does not require) the IVM to specify a Set of field name strings which the IVM intends to make. The default is to return an empty set.
2. The IVM interface also supports (but does not require) a "restrictedForm" method which is intended to return a form of the IVM which only does the indexing for the supplied set of field names (as strings). If not implemented the default is to return the same IVM. The combinedIVM now will filter through and only keep those IVMs inside which handle those fields.
3. The TextIndexer now allows a partial update with an object and a supplied set of field names. It does this by:
      3.1. Fetching the IndexedRecord stored as a full JSON document which is a "cached" version of the fields to be indexed. All facets, sorters, suggestions and fields are filtered to eliminate any of the supplied field names.
      3.2. Remove the old index entirely as with other textindexer updates
      3.3. Get the IVMs for the object but restrict to only the supplied fields as per (2) above. Calculate all new IVs and decorate the IndexedRecord accordingly.
      3.4. In turning the IndexedRecord into Lucene documents, eliminate any case where a field name attempted to be added is not in the supplied set.
      3.5. Save and build the new lucene documents as with normal updates.
4. On the create and update operations for the user list, explicitly call the textindexer special method from (3) instead of the full reindeding event (TODO: this should be refactored to use the event architecture too once the proof-of-concept is confirmed to work)

There is a corresponding other PR for substances to make the IVM for user lists work as intended.