### PR TITLE
align IVM parsing to other plugin parsing

### DIFF
--- a/gsrs-spring-legacy-indexer/src/main/java/gsrs/indexer/ConfigBasedIndexValueMakerConfiguration.java
+++ b/gsrs-spring-legacy-indexer/src/main/java/gsrs/indexer/ConfigBasedIndexValueMakerConfiguration.java
@@ -1,21 +1,23 @@
 package gsrs.indexer;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import gsrs.springUtils.AutowireHelper;
-import ix.core.search.text.IndexValueMaker;
-import lombok.Data;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import ix.core.search.text.IndexValueMaker;
+import lombok.Data;
 
 @Configuration
 @ConfigurationProperties("gsrs.indexers")
@@ -35,7 +37,31 @@ public class ConfigBasedIndexValueMakerConfiguration {
 
         private Map<String, Object> parameters;
 
+
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        private Map<String, Object> unknownParameters = new ConcurrentHashMap<>();
+
+        @JsonAnySetter
+        public void unknownSetter(String key, Object value){
+            unknownParameters.put(key, value);
+        }
+        
+        public IndexValueMaker newIndexValueMaker(ObjectMapper mapper, ClassLoader classLoader) throws ClassNotFoundException {
+
+            if(parameters !=null && !parameters.isEmpty()){
+                return (IndexValueMaker) mapper.convertValue(parameters, indexer);
+            }
+            if(unknownParameters !=null && !unknownParameters.isEmpty()){
+                return (IndexValueMaker) mapper.convertValue(unknownParameters, indexer);
+
+            }
+            return (IndexValueMaker) mapper.convertValue(Collections.emptyMap(), indexer);
+        }
+
+
+
     }
+
 
     @Bean
     @ConditionalOnMissingBean


### PR DESCRIPTION
The parsing of plugins/extensions in GSRS largely follows the same pattern:

```
extension:{
  releventClass:<class_name>,
  //optional parameters
  parameters:{
      parameter1:value1,
      ...
  }
}
```

We usually use "parameters" but also allow for the same variables to be put in the main config object instead, like:

```
extension:{
  releventClass:<class_name>,
  //optional parameters
  parameter1:value1
}
```

This is done like this for scheduledTasks, import functions, export functions, validators and a few other extensions. IVMs are one of the few that doesn't support the alternative representation. Here, this PR allows it to work like the others.