### PR TITLE
WIP: Add config prop checker and mod health controller 

### DIFF
--- a/gsrs-spring-boot-autoconfigure/pom.xml
+++ b/gsrs-spring-boot-autoconfigure/pom.xml
@@ -13,6 +13,8 @@
     <properties>
         <timestamp>${maven.build.timestamp}</timestamp>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>
+        <jackson.version>2.13.4</jackson.version>
+        <jackson.databind.version>2.13.4.2</jackson.databind.version>
     </properties>
 
     <build>
@@ -177,6 +179,42 @@
             <artifactId>gsrs-data-exchange</artifactId>
             <version>${gsrs.version}</version>
             <!--scope>compile</scope-->
+        </dependency>
+
+
+        <!-- Might not need this jackson stuff here later.  -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.databind.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-properties</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+
+
+
+
+
+
+
+        <dependency>
+            <groupId>pl.jalokim.propertiestojson</groupId>
+            <artifactId>java-properties-to-json</artifactId>
+            <version>5.3.0</version>
         </dependency>
     </dependencies>
 

--- a/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/config/ApplicationContextChecker.java
+++ b/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/config/ApplicationContextChecker.java
@@ -1,0 +1,47 @@
+package gsrs.config;
+
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.beans.factory.config.SingletonBeanRegistry;
+import org.springframework.context.ApplicationContext;
+import java.util.Arrays;
+import java.util.List;
+
+@Slf4j
+@Data
+
+public class ApplicationContextChecker {
+
+    public boolean enabled;
+
+    public String getBeanDefinitionNames(ApplicationContext ctx) {
+        List<String> omissionFragments = Arrays.asList("password","abc");
+        boolean isAdmin = true;
+        if (enabled && isAdmin) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("Beans provided by Spring Boot:\n\n");
+            String[] beanNames = ctx.getBeanDefinitionNames();
+            Arrays.sort(beanNames);
+            for (String beanName : beanNames) {
+                sb.append(beanName).append("\n");
+            }
+            return sb.toString();
+        } else {
+            return "Unauthorized.";
+        }
+    }
+
+    public String getSingletonNames(ApplicationContext applicationContext) {
+        StringBuilder sb = new StringBuilder();
+        AutowireCapableBeanFactory autowireCapableBeanFactory = applicationContext.getAutowireCapableBeanFactory();
+        if (autowireCapableBeanFactory instanceof SingletonBeanRegistry) {
+            String[] singletonNames = ((SingletonBeanRegistry) autowireCapableBeanFactory).getSingletonNames();
+            for (String singleton : singletonNames) {
+                sb.append(singleton).append("\n");
+            }
+        }
+        return sb.toString();
+    }
+}
+

--- a/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/config/ConfigurationPropertiesChecker.java
+++ b/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/config/ConfigurationPropertiesChecker.java
@@ -1,29 +1,76 @@
 package gsrs.config;
 
-import gsrs.security.GsrsSecurityUtils;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.MapPropertySource;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
+import pl.jalokim.propertiestojson.util.PropertiesToJsonConverter;
+import pl.jalokim.propertiestojson.util.PropertiesToJsonConverterBuilder;
+
+// import com.fasterxml.jackson.dataformat.javaprop.JavaPropsMapper;
+
+// https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-properties
+// https://www.adam-bien.com/roller/abien/entry/java_ee_8_converting_java
+// https://github.com/mikolajmitura/java-properties-to-json
 
 @Slf4j
 @Data
-
 public class ConfigurationPropertiesChecker {
 
     public boolean enabled;
 
-    // @Value("#{'${gsrs.config.configurationPropertyChecker.omissionFragments}'.split(',')}: ''")
-    // public List<String> omissionFragments = Arrays.asList("password");
+    public String getActivePropertiesAsJson(ConfigurableEnvironment configurableEnvironment) {
+
+        // Aside from password, this is temporary to prevent exceptions.
+        List<String> omissionFragments = Arrays.asList("password", "pattern", "regex", "relaxed");
+
+
+        //  CONSIDER how to handle security
+        boolean isAdmin = true;
+        // isAdmin = GsrsSecurityUtils.isAdmin();
+
+        if (enabled && isAdmin) {
+            List<MapPropertySource> propertySources = new ArrayList<MapPropertySource>();
+            configurableEnvironment.getPropertySources().forEach(it -> {
+                //&& it.getName().contains("applicationConfig")
+                if (it instanceof MapPropertySource) {
+                    propertySources.add((MapPropertySource) it);
+                }
+            });
+            Map<String, Object> properties = new HashMap<>();
+            propertySources.stream()
+            .map(propertySource -> propertySource.getSource().keySet())
+            .flatMap(Collection::stream)
+            .distinct()
+            .sorted()
+            .forEach(key -> {
+                // this if then is temporary
+                if(!key.equals("java.version.date") && !key.contains("java.vendor")) {
+                    try {
+                        if (omissionFragments.stream().map(s -> s.toLowerCase()).anyMatch(key.toLowerCase()::contains)) {
+                            properties.put(key, "[OMITTED VALUE]");
+                        } else {
+                            properties.put(key, configurableEnvironment.getProperty(key));
+                        }
+                    } catch (Exception e) {
+                        log.warn("{} -> {}", key, e.getMessage());
+                    }
+                }
+            });
+            PropertiesToJsonConverter converter = PropertiesToJsonConverterBuilder.builder().build();
+            String json = converter.convertFromValuesAsObjectMap(properties, false);
+            return json;
+        } else {
+            return "{ \"message\": \"Unauthorized\"}";
+        }
+    }
 
     public String getActivePropertiesAsTextBlock(ConfigurableEnvironment configurableEnvironment) {
 
-        List<String> omissionFragments = Arrays.asList("password","abc");
+        List<String> omissionFragments = Arrays.asList("password");
 
+        //  CONSIDER how to handle security
         boolean isAdmin = true;
         // isAdmin = GsrsSecurityUtils.isAdmin();
 
@@ -32,7 +79,7 @@ public class ConfigurationPropertiesChecker {
             List<MapPropertySource> propertySources = new ArrayList<MapPropertySource>();
 
             sb.append("**** BEGIN ACTIVE APP PROPERTIES ****").append("\n\n");
-            sb.append("eabled: ").append(enabled).append("\n");
+            sb.append("enabled: ").append(enabled).append("\n");
             sb.append("Groups:").append("\n\n");
 
             configurableEnvironment.getPropertySources().forEach(it -> {
@@ -42,7 +89,7 @@ public class ConfigurationPropertiesChecker {
                     propertySources.add((MapPropertySource) it);
                 }
             });
-            sb.append("Properties:").append("\n\n");
+            sb.append("\n\nProperties:").append("\n\n");
             propertySources.stream()
             .map(propertySource -> propertySource.getSource().keySet())
             .flatMap(Collection::stream)

--- a/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/config/ConfigurationPropertiesChecker.java
+++ b/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/config/ConfigurationPropertiesChecker.java
@@ -1,0 +1,69 @@
+package gsrs.config;
+
+import gsrs.security.GsrsSecurityUtils;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+@Slf4j
+@Data
+
+public class ConfigurationPropertiesChecker {
+
+    public boolean enabled;
+
+    // @Value("#{'${gsrs.config.configurationPropertyChecker.omissionFragments}'.split(',')}: ''")
+    // public List<String> omissionFragments = Arrays.asList("password");
+
+    public String getActivePropertiesAsTextBlock(ConfigurableEnvironment configurableEnvironment) {
+
+        List<String> omissionFragments = Arrays.asList("password","abc");
+
+        boolean isAdmin = true;
+        // isAdmin = GsrsSecurityUtils.isAdmin();
+
+        if (enabled && isAdmin) {
+            StringBuilder sb = new StringBuilder();
+            List<MapPropertySource> propertySources = new ArrayList<MapPropertySource>();
+
+            sb.append("**** BEGIN ACTIVE APP PROPERTIES ****").append("\n\n");
+            sb.append("eabled: ").append(enabled).append("\n");
+            sb.append("Groups:").append("\n\n");
+
+            configurableEnvironment.getPropertySources().forEach(it -> {
+                //&& it.getName().contains("applicationConfig")
+                if (it instanceof MapPropertySource) {
+                    sb.append(it.getName()).append("\n");
+                    propertySources.add((MapPropertySource) it);
+                }
+            });
+            sb.append("Properties:").append("\n\n");
+            propertySources.stream()
+            .map(propertySource -> propertySource.getSource().keySet())
+            .flatMap(Collection::stream)
+            .distinct()
+            .sorted()
+            .forEach(key -> {
+                try {
+                    if(omissionFragments.stream().map(s->s.toLowerCase()).anyMatch(key.toLowerCase()::contains)) {
+                         sb.append(key + "=").append("[OMITTED VALUE]\n");
+                     } else {
+                         sb.append(key + "=" + configurableEnvironment.getProperty(key)).append("\n");
+                     }
+                } catch (Exception e) {
+                    log.warn("{} -> {}", key, e.getMessage());
+                }
+            });
+            sb.append("**** END ACTIVE APP PROPERTIES ****");
+            return sb.toString();
+        } else {
+            return "Unauthorized.";
+        }
+    }
+}
+

--- a/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/controller/AbstractGsrsEntityController.java
+++ b/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/controller/AbstractGsrsEntityController.java
@@ -392,6 +392,12 @@ public abstract class AbstractGsrsEntityController<C extends AbstractGsrsEntityC
         }
     }
 
+//    @Override
+//    @GetGsrsRestApiMapping("/@configurationProperties")
+//    public String getConfigurationProperties(){
+//        return getEntityService().getConfigurationProperties();
+//    }
+
 
 
     @Override

--- a/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/controller/GsrsEntityController.java
+++ b/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/controller/GsrsEntityController.java
@@ -35,6 +35,9 @@ public interface GsrsEntityController<T, I> {
     @GetGsrsRestApiMapping(value={"({id})/**", "/{id}/**"  })
     ResponseEntity<Object> getFieldById(@PathVariable String id, @RequestParam(value="urldecode", required = false) Boolean urlDecode, @RequestParam Map<String, String> queryParameters, HttpServletRequest request) throws UnsupportedEncodingException;
 
+//    @GetGsrsRestApiMapping("/@configurationProperties")
+//    public String getConfigurationProperties();
+
     @GetGsrsRestApiMapping("/@count")
     long getCount();
 

--- a/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/controller/HealthController.java
+++ b/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/controller/HealthController.java
@@ -10,14 +10,19 @@ import java.util.stream.Collectors;
 
 import javax.sql.DataSource;
 
+import gsrs.config.ConfigurationPropertiesChecker;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.boot.jdbc.metadata.HikariDataSourcePoolMetadata;
 import org.springframework.context.event.EventListener;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
 import org.springframework.hateoas.server.ExposesResourceFor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.zaxxer.hikari.HikariDataSource;
@@ -43,6 +48,12 @@ public class HealthController {
 
     @Autowired(required = false)
     private GsrsCache gsrsCache;
+
+    @Autowired
+    ConfigurableEnvironment configurableEnvironment;
+
+    @Autowired
+    Environment env;
 
     private long startTime =System.currentTimeMillis();
 
@@ -70,6 +81,34 @@ public class HealthController {
     public List<GsrsControllerInfo> getControllerInfo(){
         return controllerMapper.getControllerInfos().collect(Collectors.toList());
     }
+
+    // Need to edit all health end points to include a context url path variable
+    @GetMapping("api/v1/clinicaltrialsus/health")
+    public UpStatus isCtUp(){
+        return UpStatus.INSTANCE;
+    }
+
+    @GetMapping(value="api/v1/{context}/health/@configurableEnvironment1", produces = MediaType.TEXT_PLAIN_VALUE)
+    public @ResponseBody
+    String checkConfigurationProperties(@PathVariable(value="context") String context) {
+        ConfigurationPropertiesChecker c = new ConfigurationPropertiesChecker();
+        c.setEnabled(
+            Boolean.parseBoolean(env.getProperty("gsrs.config.report.properties.enabled"))
+        );
+        return c.getActivePropertiesAsTextBlock(configurableEnvironment);
+    }
+
+    @GetMapping(value="api/v1/{context}/health/@configurableEnvironment2", produces = MediaType.TEXT_PLAIN_VALUE)
+    public @ResponseBody
+    String checkConfigurationProperties2(@PathVariable(value="context") String context) {
+        ConfigurationPropertiesChecker c = new ConfigurationPropertiesChecker();
+        c.setEnabled(
+        Boolean.parseBoolean(env.getProperty("gsrs.config.report.properties.enabled"))
+        );
+        return c.getActivePropertiesAsJson(configurableEnvironment);
+    }
+
+
 
     @GetMapping("api/v1/health")
     public UpStatus isUp(){

--- a/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/service/GsrsEntityService.java
+++ b/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/service/GsrsEntityService.java
@@ -47,6 +47,8 @@ public interface GsrsEntityService<T, I> {
      */
     long count();
 
+//    String getConfigurationProperties();
+
     /**
      * Remove the given entity from the repository.
      * @param id the id of the entity to delete.


### PR DESCRIPTION
This PR creates endpoints so that (admin) users can examine configuration as it exists in a given microservice. 

have so far tried context = clinicaltrialsus but I think it will work for others

text block end point
api/v1/{context}/health/@configurableEnvironment1

json end point (at this point son but in plain text response)
api/v1/{context}/health/@configurableEnvironment2