### PR TITLE
add default sorting order with search results

### DIFF
--- a/gsrs-controlled-vocabulary-api/pom.xml
+++ b/gsrs-controlled-vocabulary-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gsrs-spring-boot</artifactId>
         <groupId>gov.nih.ncats</groupId>
-        <version>3.1</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gsrs-controlled-vocabulary/pom.xml
+++ b/gsrs-controlled-vocabulary/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gsrs-spring-boot</artifactId>
         <groupId>gov.nih.ncats</groupId>
-        <version>3.1</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gsrs-core-entities/pom.xml
+++ b/gsrs-core-entities/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gsrs-spring-boot</artifactId>
         <groupId>gov.nih.ncats</groupId>
-        <version>3.1</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gsrs-core-test/pom.xml
+++ b/gsrs-core-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gsrs-spring-boot</artifactId>
         <groupId>gov.nih.ncats</groupId>
-       <version>3.1</version>
+       <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gsrs-core/pom.xml
+++ b/gsrs-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gsrs-spring-boot</artifactId>
         <groupId>gov.nih.ncats</groupId>
-        <version>3.1</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gsrs-data-exchange/pom.xml
+++ b/gsrs-data-exchange/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gsrs-spring-boot</artifactId>
         <groupId>gov.nih.ncats</groupId>
-        <version>3.1</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gsrs-discovery/pom.xml
+++ b/gsrs-discovery/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>gov.nih.ncats</groupId>
     <artifactId>gsrs-discovery</artifactId>
-    <version>3.1</version>
+    <version>3.1.1-SNAPSHOT</version>
     <name>gsrs-discovery</name>
     <description>Demo project for Spring Boot</description>
 

--- a/gsrs-rest-api/pom.xml
+++ b/gsrs-rest-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gsrs-spring-boot</artifactId>
         <groupId>gov.nih.ncats</groupId>
-       <version>3.1</version>
+       <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gsrs-scheduled-tasks/pom.xml
+++ b/gsrs-scheduled-tasks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gsrs-spring-boot</artifactId>
         <groupId>gov.nih.ncats</groupId>
-        <version>3.1</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gsrs-spring-akka/pom.xml
+++ b/gsrs-spring-akka/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gsrs-spring-boot</artifactId>
         <groupId>gov.nih.ncats</groupId>
-        <version>3.1</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gsrs-spring-boot-autoconfigure/pom.xml
+++ b/gsrs-spring-boot-autoconfigure/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gsrs-spring-boot</artifactId>
         <groupId>gov.nih.ncats</groupId>
-        <version>3.1</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gsrs-spring-boot-starter/pom.xml
+++ b/gsrs-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gsrs-spring-boot</artifactId>
         <groupId>gov.nih.ncats</groupId>
-        <version>3.1</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gsrs-spring-legacy-cache/pom.xml
+++ b/gsrs-spring-legacy-cache/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gsrs-spring-boot</artifactId>
         <groupId>gov.nih.ncats</groupId>
-        <version>3.1</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gsrs-spring-legacy-indexer/pom.xml
+++ b/gsrs-spring-legacy-indexer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gsrs-spring-boot</artifactId>
         <groupId>gov.nih.ncats</groupId>
-        <version>3.1</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gsrs-spring-legacy-sequence-indexer/pom.xml
+++ b/gsrs-spring-legacy-sequence-indexer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gsrs-spring-boot</artifactId>
         <groupId>gov.nih.ncats</groupId>
-        <version>3.1</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gsrs-spring-legacy-structure-indexer/pom.xml
+++ b/gsrs-spring-legacy-structure-indexer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gsrs-spring-boot</artifactId>
         <groupId>gov.nih.ncats</groupId>
-        <version>3.1</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gsrs-spring-starter-tests/pom.xml
+++ b/gsrs-spring-starter-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>gsrs-spring-boot</artifactId>
         <groupId>gov.nih.ncats</groupId>
-        <version>3.1</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,13 +30,13 @@
     </parent>
     <properties>
         <java.version>1.8</java.version>
-        <gsrs.version>3.1</gsrs.version>
+        <gsrs.version>3.1.1-SNAPSHOT</gsrs.version>
         <spring-boot.version>2.4.5</spring-boot.version>
         <log4j2.version>2.17.2</log4j2.version>
     </properties>
     <groupId>gov.nih.ncats</groupId>
     <artifactId>gsrs-spring-boot</artifactId>
-    <version>3.1</version>
+    <version>3.1.1-SNAPSHOT</version>
     <name>gsrs-starter</name>
     <description>Spring Starter for GSRS project</description>
     <url>https://github.com/ncats/gsrs-spring-starter</url>


### PR DESCRIPTION
For calls like with an order like /api/v1/codes/?view=keys&top=100&skip=0&order=version, it works file.

For calls to this without setting a sort order: /api/v1/applications/?view=key&top=100&skip=100000, the results will be back without consistence for multiple calls since the default order is not set correctly in the backend.  This PR is to fix the default sorting order. 

