### PR TITLE
update self url

### DIFF
--- a/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/controller/AbstractLegacyTextSearchGsrsEntityController.java
+++ b/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/controller/AbstractLegacyTextSearchGsrsEntityController.java
@@ -172,9 +172,11 @@ public abstract class AbstractLegacyTextSearchGsrsEntityController<C extends Abs
     
     @GetGsrsRestApiMapping(value="/@reindexBulk({id})", apiVersions = 1)
     public ResponseEntity bulkReindexStatus(@PathVariable("id") String id, @RequestParam Map<String, String> queryParameters,
-    		HttpServletRequest request){    	
+    		HttpServletRequest request){
+    	
+    	String self_url = StaticContextAccessor.getBean(IxContext.class).getEffectiveAdaptedURI(request).toString();
     	return Optional.ofNullable(reindexing.get(id)).map(o->{
-    		o.set_self(request.getRequestURL().toString());
+    		o.set_self(self_url);
     		return new ResponseEntity<>(o, HttpStatus.OK);	
     	})
     	.map(oo->(ResponseEntity)oo)


### PR DESCRIPTION
This is to fix the issue that the endpoint of getting the status of a reindexBulk job returns the _self as the url of the request: localhost:8080,  when it is supposed to be hostname and port. 

Get:   /api/v1/substances/@reindexBulk(3f2c825f-c763-4100-b7d8-c166f661fd1d)
Below is an example return data of this endpoint. 
{
    "statusID": "3f2c825f-c763-4100-b7d8-c166f661fd1d",
    "status": "indexing record 2 of 2",
    "total": 2,
    "indexed": 1,
    "failed": 0,
    "done": false,
    "start": 1703102889883,
    "finshed": 0,
    "ids": [
        "306d24b9-a6b8-4091-8024-02f9ec24b705",
        "90e9191d-1a81-4a53-b7ee-560bf9e68109"
    ],
    "_self": "http://localhost:8081/api/v1/substances/@reindexBulk(3f2c825f-c763-4100-b7d8-c166f661fd1d)"
}