### PR TITLE
WIP:  path traversal mitigation attempt raised snyk analysis

### DIFF
--- a/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/config/FilePathParserUtils.java
+++ b/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/config/FilePathParserUtils.java
@@ -103,34 +103,4 @@ public class FilePathParserUtils {
         }
     }
 
-// Probably delete this
-//    public static void failIfDirectoryTraversal(String baseDirectoryPath , String relativePath)
-//    {
-//        File relativePathFile = Paths.get(relativePath).toFile();
-//        if (relativePathFile.isAbsolute()) {
-//            throw new RuntimeException("Directory traversal attempt - absolute path not allowed");
-//        }
-//        String combinedPathUsingCanonical;
-//        String combinedPathUsingAbsolute;
-//
-//        try
-//        {
-//            combinedPathUsingCanonical =Paths.get(baseDirectoryPath, relativePath).toFile().getCanonicalPath();
-//            combinedPathUsingAbsolute = Paths.get(baseDirectoryPath, relativePath).toFile().getAbsolutePath();
-//        }
-//        catch (IOException e)
-//        {
-//            throw new RuntimeException("Directory traversal attempt?", e);
-//        }
-//        // Require the absolute path and canonicalized path match.
-//        // This is done to avoid directory traversal
-//        // attacks, e.g. "1/../2/"
-//        if (! combinedPathUsingCanonical.equals(combinedPathUsingAbsolute))
-//        {
-//            throw new RuntimeException("Directory traversal attempt?");
-//        }
-//    }
-
-
-
 }

--- a/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/config/FilePathParserUtils.java
+++ b/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/config/FilePathParserUtils.java
@@ -1,7 +1,10 @@
 package gsrs.config;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.format.DateTimeFormatter;
 
 import gov.nih.ncats.common.util.TimeUtil;
@@ -77,5 +80,57 @@ public class FilePathParserUtils {
         }
         return null;
     }
+
+    public static void failOnBadPathResolution(String basePath, String passedPath)
+    throws InvalidPathException, IOException {
+        Path basePathObj;
+        Path resolvedPathObj;
+        try {
+            basePathObj = Paths.get(basePath);
+            resolvedPathObj = basePathObj.resolve(passedPath);
+//            System.out.println("getPath       : " + resolvedPathObj.toFile().getPath());
+//            System.out.println("getAbsPath    : " + resolvedPathObj.toFile().getAbsolutePath());
+//            System.out.println("getNormAbsPath: " + resolvedPathObj.normalize().toAbsolutePath());
+        } catch (InvalidPathException ipe) {
+            // Don't want to provide input path as it might get flagged.
+            throw new InvalidPathException("Relating to passedPath", "Exception while resolving path");
+        }
+        if (Paths.get(passedPath).isAbsolute()) {
+            throw new IOException("Absolute path not allowed.");
+        }
+        if (!resolvedPathObj.normalize().startsWith(basePathObj)) {
+            throw new IOException("Unexpected start of path.");
+        }
+    }
+
+// Probably delete this
+//    public static void failIfDirectoryTraversal(String baseDirectoryPath , String relativePath)
+//    {
+//        File relativePathFile = Paths.get(relativePath).toFile();
+//        if (relativePathFile.isAbsolute()) {
+//            throw new RuntimeException("Directory traversal attempt - absolute path not allowed");
+//        }
+//        String combinedPathUsingCanonical;
+//        String combinedPathUsingAbsolute;
+//
+//        try
+//        {
+//            combinedPathUsingCanonical =Paths.get(baseDirectoryPath, relativePath).toFile().getCanonicalPath();
+//            combinedPathUsingAbsolute = Paths.get(baseDirectoryPath, relativePath).toFile().getAbsolutePath();
+//        }
+//        catch (IOException e)
+//        {
+//            throw new RuntimeException("Directory traversal attempt?", e);
+//        }
+//        // Require the absolute path and canonicalized path match.
+//        // This is done to avoid directory traversal
+//        // attacks, e.g. "1/../2/"
+//        if (! combinedPathUsingCanonical.equals(combinedPathUsingAbsolute))
+//        {
+//            throw new RuntimeException("Directory traversal attempt?");
+//        }
+//    }
+
+
 
 }

--- a/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/controller/ExportController.java
+++ b/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/controller/ExportController.java
@@ -185,10 +185,6 @@ public class ExportController {
 
         File f = exportFile.get().getFile();
 
-        // __aw__ come back
-        // FilePathParserUtils.failIfDirectoryTraversal(f.getPath());
-
-
         Path path = Paths.get(f.getAbsolutePath());
         ByteArrayResource resource = new ByteArrayResource(Files.readAllBytes(path));
 

--- a/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/controller/ExportController.java
+++ b/gsrs-spring-boot-autoconfigure/src/main/java/gsrs/controller/ExportController.java
@@ -1,5 +1,6 @@
 package gsrs.controller;
 
+import gsrs.config.FilePathParserUtils;
 import gsrs.service.ExportService;
 import ix.ginas.exporters.ExportDir;
 import ix.ginas.exporters.ExportMetaData;
@@ -184,6 +185,8 @@ public class ExportController {
 
         File f = exportFile.get().getFile();
 
+        // __aw__ come back
+        // FilePathParserUtils.failIfDirectoryTraversal(f.getPath());
 
 
         Path path = Paths.get(f.getAbsolutePath());

--- a/gsrs-spring-boot-autoconfigure/src/test/java/gsrs/config/TestFileParserHelper.java
+++ b/gsrs-spring-boot-autoconfigure/src/test/java/gsrs/config/TestFileParserHelper.java
@@ -2,14 +2,8 @@ package gsrs.config;
 
 import java.io.File;
 import java.io.IOException;
-
-import org.apache.commons.lang3.SystemUtils;
 import org.junit.jupiter.api.Test;
-
 import gsrs.config.FilePathParserUtils.FileParser;
-
-import javax.swing.plaf.synth.SynthTextAreaUI;
-
 import static org.junit.jupiter.api.Assertions.*;
 
 

--- a/gsrs-spring-boot-autoconfigure/src/test/java/gsrs/config/TestFileParserHelper.java
+++ b/gsrs-spring-boot-autoconfigure/src/test/java/gsrs/config/TestFileParserHelper.java
@@ -1,13 +1,16 @@
 package gsrs.config;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import java.io.File;
 import java.io.IOException;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.jupiter.api.Test;
 
 import gsrs.config.FilePathParserUtils.FileParser;
+
+import javax.swing.plaf.synth.SynthTextAreaUI;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 
 public class TestFileParserHelper {
@@ -99,8 +102,6 @@ public class TestFileParserHelper {
         
         assertEquals(new File("test").toPath().normalize(), f.toPath().normalize());
     }
-    
-
 
     @Test
     public void nullSuppliedGivenDefaultRelativeWithSetRootShouldBeAbsolute() throws IOException {
@@ -112,6 +113,70 @@ public class TestFileParserHelper {
 
         assertEquals(new File("/tmp/test"), f);
     }
-    
-    
+
+    @Test
+    public void testFailOnBadPathResolutionNormal() throws IOException {
+        boolean hasException = false;
+        try {
+            // Should succeed since normalized path ok
+            FilePathParserUtils.failOnBadPathResolution("/tmp", "my-file.txt");
+        } catch(Exception e) {
+            System.out.println(e.getMessage());
+            hasException = true;
+        }
+        assertFalse(hasException);
+    }
+
+    @Test
+    public void testFailOnBadPathResolutionSingleDot1() throws IOException {
+        boolean hasException = false;
+        try {
+            // Should succeed since path resolves to /tmp/my-file.txt
+            FilePathParserUtils.failOnBadPathResolution("/tmp", "./my-file.txt");
+        } catch(Exception e) {
+            System.out.println(e.getMessage());
+            hasException = true;
+        }
+        assertFalse(hasException);
+    }
+
+    @Test
+    public void testFailOnBadPathResolutionDotDot1() throws IOException {
+        boolean hasException = false;
+        try {
+            // Should succeed since path resolves to /tmp/my-file.txt
+            FilePathParserUtils.failOnBadPathResolution("/tmp", "../tmp/my-file.txt");
+        } catch(Exception e) {
+            System.out.println(e.getMessage());
+            hasException = true;
+        }
+        assertFalse(hasException);
+    }
+
+    @Test
+    public void testFailOnBadPathResolutionDotDot2() throws IOException {
+        boolean hasException = false;
+        try {
+            // Should fail since path resolves to /etc/my-file.txt
+            FilePathParserUtils.failOnBadPathResolution("/tmp", "../etc/my-file.txt");
+        } catch(Exception e) {
+            System.out.println(e.getMessage());
+            hasException = true;
+        }
+        assertTrue(hasException);
+    }
+
+    @Test
+    public void testFailOnBadPathResolutionAbsolutePathException() throws IOException {
+        boolean hasException = false;
+        try {
+            // Should fail due to absolute path
+            FilePathParserUtils.failOnBadPathResolution("/tmp", "/my/abs/path");
+        } catch(Exception e) {
+            System.out.println(e.getMessage());
+            hasException = true;
+        }
+        assertTrue(hasException);
+    }
+
 }


### PR DESCRIPTION
with multipart form it is possible for hacker to pass a folder for the filename or paths like this ../etc/passwd 

so we need to make sure the final path to file starts with the expected base path and when normalized points a reasonable location. 

