### PR TITLE
WIP: Try out higher version (3.5.5) and Java 17 compile on starter compared to 3.2.0

### DIFF
--- a/gsrs-controlled-vocabulary-api/pom.xml
+++ b/gsrs-controlled-vocabulary-api/pom.xml
@@ -43,8 +43,8 @@
     </scm>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/gsrs-controlled-vocabulary/pom.xml
+++ b/gsrs-controlled-vocabulary/pom.xml
@@ -12,8 +12,8 @@
     <artifactId>gsrs-controlled-vocabulary</artifactId>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 
     <name>gsrs-controlled-vocabulary</name>

--- a/gsrs-data-exchange/pom.xml
+++ b/gsrs-data-exchange/pom.xml
@@ -43,8 +43,8 @@
     </scm>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/gsrs-discovery/pom.xml
+++ b/gsrs-discovery/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.0</version>
+        <version>3.4.9</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>gov.nih.ncats</groupId>
@@ -45,7 +45,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <spring-cloud.version>2022.0.5</spring-cloud.version>
+        <spring-cloud.version>2024.0.2</spring-cloud.version>
     </properties>
 
     <dependencies>
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <version>3.2.0</version>
+            <version>3.4.9</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/gsrs-rest-api/pom.xml
+++ b/gsrs-rest-api/pom.xml
@@ -42,8 +42,8 @@
     </scm>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/gsrs-service-utilities/pom.xml
+++ b/gsrs-service-utilities/pom.xml
@@ -42,8 +42,8 @@
         <url>https://github.com/ncats/gsrs-spring-starter.git</url>
     </scm>
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <gsrs-services-common.version>1.0-SNAPSHOT</gsrs-services-common.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,15 +26,16 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.0</version>
+        <version>3.4.9</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <properties>
         <java.version>17</java.version>
         <gsrs.version>3.1.3-SNAPSHOT</gsrs.version>
-        <spring-boot.version>3.2.0</spring-boot.version>
+        <spring-boot.version>3.4.9</spring-boot.version>
         <log4j2.version>2.22.1</log4j2.version>
         <lombok.version>1.18.30</lombok.version>
+        <spring-cloud.version>2024.0.2</spring-cloud.version>
     </properties>
     <groupId>gov.nih.ncats</groupId>
     <artifactId>gsrs-spring-boot</artifactId>


### PR DESCRIPTION
This builds but tests fail

 gsrs-spring-starter-tests/src/test/java/gsrs/startertests/GsrsSpringApplication.java
 
 The conditional on missing bean causes problems, 
 
 @ConditionalOnMissingBean(UserProfileRepository.class)

 if I disable it the next thing that happens is

Try running CreateAndModifyDateFieldTest.java 
 intialCreationShouldSetCreateDateAndLastModifiedToSameValue 

 Caused by: org.hibernate.AnnotationException: Property 'gsrs.stagingarea.model.ImportData.recordId' is annotated @GeneratedValue but is not part of an identifier
